### PR TITLE
Simply activate and show the ArenaWidget if its open but not the visible

### DIFF
--- a/eiskaltdcpp-qt/src/MainWindow.cpp
+++ b/eiskaltdcpp-qt/src/MainWindow.cpp
@@ -1969,7 +1969,10 @@ void MainWindow::toggleSingletonWidget(ArenaWidget *a){
         a->setToolButton(act);
     }
    
-    ArenaWidgetManager::getInstance()->toggle(a);
+    if (!a->getWidget()->isVisible())
+        ArenaWidgetManager::getInstance()->activate(a);
+    else
+        ArenaWidgetManager::getInstance()->toggle(a);
 }
 
 void MainWindow::toggleMainMenu(bool showMenu){


### PR DESCRIPTION
Scenario:
I open an ArenaWidget (Queued Downloads/Finished Transfers/etc). I then open another tab (say, a search). Do some stuff there, and I want to get back to the ArenaWidget I had opened (which I had not closed). So I click on the corresponding icon from the toolbar.

What happens:
The ArenaWidget toggles (closes, in this case).

What should happen/what happens after this commit:
The ArenaWidget is simply activated and shown.

Tests:
Tested with both the cases (clicking the toolbar icon with/without the ArenaWidget being visible as current tab), and gives expected results for both cases.
