### PR TITLE
Expand root directory on left pane of the share browser

### DIFF
--- a/eiskaltdcpp-qt/src/ShareBrowser.cpp
+++ b/eiskaltdcpp-qt/src/ShareBrowser.cpp
@@ -296,6 +296,7 @@ void ShareBrowser::init(){
     treeView_LPANE->setModel(tree_model);
     treeView_LPANE->header()->hideSection(COLUMN_FILEBROWSER_ESIZE);
     treeView_LPANE->header()->hideSection(COLUMN_FILEBROWSER_TTH);
+    treeView_LPANE->setExpanded(tree_model->index(0, 0), true);
     treeView_LPANE->setContextMenuPolicy(Qt::CustomContextMenu);
 
     treeView_RPANE->setModel(list_model);


### PR DESCRIPTION
This commit expands the lef pane's root directory of a file list on opening the share browser.
