### PR TITLE
Qt UI:

### DIFF
--- a/eiskaltdcpp-qt/src/HubFrame.cpp
+++ b/eiskaltdcpp-qt/src/HubFrame.cpp
@@ -301,8 +301,7 @@ HubFrame::Menu::Action HubFrame::Menu::execUserMenu(Client *client, const QStrin
     QMenu *user_menu = NULL;
 
     if (!cid.isEmpty()){
-        user_menu = WulforUtil::getInstance()->buildUserCmdMenu(QStringList()
-                        << _q(client->getHubUrl()), UserCommand::CONTEXT_USER);
+        user_menu = WulforUtil::getInstance()->buildUserCmdMenu(client->getHubUrl(), UserCommand::CONTEXT_USER);
 
         if (user_menu->actions().size() > 0)
             menu->addMenu(user_menu);
@@ -348,7 +347,7 @@ HubFrame::Menu::Action HubFrame::Menu::execUserMenu(Client *client, const QStrin
 
         StringMap params;
 
-        if (WulforUtil::getInstance()->getUserCommandParams(last_user_cmd, params)){
+        if (WulforUtil::getInstance()->getUserCommandParams(uc, params)){
             UserPtr user = ClientManager::getInstance()->findUser(CID(cid.toStdString()));
 
             if (user)
@@ -396,8 +395,7 @@ HubFrame::Menu::Action HubFrame::Menu::execChatMenu(Client *client, const QStrin
     QMenu *user_menu = NULL;
 
     if (!cid.isEmpty() && !pmw){
-        user_menu = WulforUtil::getInstance()->buildUserCmdMenu(QStringList()
-                        << _q(client->getHubUrl()), UserCommand::CONTEXT_HUB);
+        user_menu = WulforUtil::getInstance()->buildUserCmdMenu(client->getHubUrl(), UserCommand::CONTEXT_HUB);
 
     if (user_menu->actions().size() > 0)
         menu->addMenu(user_menu);
@@ -441,7 +439,7 @@ HubFrame::Menu::Action HubFrame::Menu::execChatMenu(Client *client, const QStrin
 
         StringMap params;
 
-        if (WulforUtil::getInstance()->getUserCommandParams(last_user_cmd, params)){
+        if (WulforUtil::getInstance()->getUserCommandParams(uc, params)){
             UserPtr user = ClientManager::getInstance()->findUser(CID(cid.toStdString()));
 
             if (user)
@@ -1267,7 +1265,7 @@ void HubFrame::initMenu(){
     d->arenaMenu->addMenu(copyInfo);
 
     if (d->client && d->client->isConnected()){
-        QMenu *u_c = WulforUtil::getInstance()->buildUserCmdMenu(QList<QString>() << _q(d->client->getHubUrl()), UserCommand::CONTEXT_HUB, d->arenaMenu);
+        QMenu *u_c = WulforUtil::getInstance()->buildUserCmdMenu(d->client->getHubUrl(), UserCommand::CONTEXT_HUB, d->arenaMenu);
 
         if (u_c){
             if (u_c->actions().size() > 0){
@@ -3585,7 +3583,7 @@ void HubFrame::slotHubMenu(QAction *res){
         StringMap params;
         Q_D(HubFrame);
 
-        if (WulforUtil::getInstance()->getUserCommandParams(last_user_cmd, params)){
+        if (WulforUtil::getInstance()->getUserCommandParams(uc, params)){
             d->client->getMyIdentity().getParams(params, "my", true);
             d->client->getHubIdentity().getParams(params, "hub", false);
 

--- a/eiskaltdcpp-qt/src/SearchFrame.cpp
+++ b/eiskaltdcpp-qt/src/SearchFrame.cpp
@@ -1484,7 +1484,7 @@ void SearchFrame::slotContextMenu(const QPoint &){
 
                 StringMap params;
 
-                if (WulforUtil::getInstance()->getUserCommandParams(last_user_cmd, params)){
+                if (WulforUtil::getInstance()->getUserCommandParams(uc, params)){
                     UserPtr user = ClientManager::getInstance()->findUser(CID(item->cid.toStdString()));
 
                     if (user && user->isOnline()){

--- a/eiskaltdcpp-qt/src/WulforUtil.h
+++ b/eiskaltdcpp-qt/src/WulforUtil.h
@@ -150,7 +150,7 @@ public:
     QString dcEnc2QtEnc(QString);
     QStringList encodings();
 
-    bool getUserCommandParams(QString, dcpp::StringMap &);
+    bool getUserCommandParams(const UserCommand& uc, StringMap& params);
 
     QStringList getLocalIPs();
     QStringList getLocalIfaces();
@@ -171,6 +171,8 @@ public:
 
     QString compactToolTipText(QString, int, QString);
 
+    QMenu *buildUserCmdMenu(const std::string &hub_url, int ctx, QWidget* = 0);
+    QMenu *buildUserCmdMenu(const StringList& hub_list, int ctx, QWidget* = 0);
     QMenu *buildUserCmdMenu(const QList<QString> &hub_list, int ctx, QWidget* = 0);
 
     static bool isTTH(const QString &text);


### PR DESCRIPTION
- fixed - user commands editor now fully work with the types of commands chat/pm/raw (ADC/NMDC) (Issue 958)
- fixed - errors when the select usercommand (ADC/NMDC)
- added - extend %[line:] to create combo boxes (ADC/NMDC)

Изменения:
1. Команды с типом chat и pm созданные в редакторе команд - работают.
2. При построении меню разделители расставлялись не корректно.
3. Не обрабатывались "\s" (пробелы) в юзер командах adc протокола.
4. Расширенный вариант %[line] в параметрах юзер команды - %[line:заголовок списка/строка выбираемая по умолчанию/строка1/строка2/строкаNN] --> https://bugs.launchpad.net/dcplusplus/+bug/505450
