### PR TITLE
Web UI: select search tab automatically when search param is set in uri

### DIFF
--- a/eiskaltdcpp-web/eiskaltdcpp-web.js
+++ b/eiskaltdcpp-web/eiskaltdcpp-web.js
@@ -247,7 +247,7 @@ var eiskalt = (function () {
 
         requestStatisticalData: function () {
             $.jsonRPC.request('show.ratio', {
-                success : eiskalt.updateStatisticalData,
+                success : eiskalt.updateStatisticalData
             });
         },
 
@@ -328,6 +328,7 @@ var eiskalt = (function () {
 
             searchString = eiskalt.getURLParameter('search');
             if (searchString !== null) {
+                $('#tab-container').easytabs('select', '#tab-search');
                 $('input#searchstring').val(searchString);
                 eiskalt.onSearchClicked();
             }


### PR DESCRIPTION
Tested your changes on the web ui and all seems fine.
But because of the changed tab order the search results are not directly visible, when searching via the uri search parameter.
