### PR TITLE
Qt UI: Fixed compile with Qt5

### DIFF
--- a/eiskaltdcpp-qt/src/ArenaWidget.h
+++ b/eiskaltdcpp-qt/src/ArenaWidget.h
@@ -97,7 +97,7 @@ Q_OBJECT
 Q_INTERFACES(ArenaWidget)
 
 public:
-    Q_ENUMS (ArenaWidget::Flags);
+//    Q_ENUMS (ArenaWidget::Flags);
 
     ScriptWidget();
     virtual ~ScriptWidget();


### PR DESCRIPTION
Из-за этой строчки не собирается с Qt5. moc ничего разумного не генерирует на этот код. Видимо Negativ просто забыл его удалить.
