### PR TITLE
TransferView patch

### DIFF
--- a/eiskaltdcpp-qt/src/TransferView.cpp
+++ b/eiskaltdcpp-qt/src/TransferView.cpp
@@ -216,6 +216,8 @@ void TransferView::init(){
     connect(treeView_TRANSFERS, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(slotContextMenu(QPoint)));
     connect(treeView_TRANSFERS->header(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(slotHeaderMenu(QPoint)));
 
+    connect (checkBox_showTranferedFilesOnly, SIGNAL(stateChanged(int)), this, SLOT(slotcheckState(int)));
+
     connect(this, SIGNAL(coreDMRequesting(VarMap)),     model, SLOT(initTransfer(VarMap)), Qt::QueuedConnection);
     connect(this, SIGNAL(coreDMStarting(VarMap)),       model, SLOT(updateTransfer(VarMap)), Qt::QueuedConnection);
     connect(this, SIGNAL(coreDMTick(VarMap)),           model, SLOT(updateTransfer(VarMap)), Qt::QueuedConnection);
@@ -239,6 +241,10 @@ void TransferView::init(){
 
     load();
 }
+
+void TransferView::slotcheckState(int state){
+    model->handleShowTranferedFilesOnlyState(state);
+};
 
 void TransferView::getFileList(const QString &cid, const QString &host){
     if (cid.isEmpty() || host.isEmpty())

--- a/eiskaltdcpp-qt/src/TransferView.h
+++ b/eiskaltdcpp-qt/src/TransferView.h
@@ -148,6 +148,7 @@ private Q_SLOTS:
     void slotContextMenu(const QPoint&);
     void slotHeaderMenu(const QPoint&);
     void downloadComplete(QString);
+    void slotcheckState(int);
     \
 private:
     TransferView(QWidget* = NULL);

--- a/eiskaltdcpp-qt/src/TransferViewModel.cpp
+++ b/eiskaltdcpp-qt/src/TransferViewModel.cpp
@@ -360,6 +360,13 @@ void TransferViewModel::addConnection(const VarMap &params){
 
     transfer_hash.insertMulti(item->cid, item);
 
+    if (showTranferedFilesOnly){
+        if (vstr(params["FNAME"]).isEmpty() || (tr("File list") == params["FNAME"]) ){
+            return;
+        };
+    };
+
+
     if (!to)
         rootItem->appendChild(item);
     else
@@ -391,7 +398,16 @@ void TransferViewModel::updateTransfer(const VarMap &params){
     item->fail = vbol(params["FAIL"]);
     item->tth = vstr(params["TTH"]);
 
+
+
     if (!vbol(params["DOWN"])){
+
+        if (showTranferedFilesOnly){
+            if (vstr(params["FNAME"]).isEmpty() || (tr("File list") == params["FNAME"]) ){
+                return;
+            };
+        };
+
         if (!rootItem->childItems.contains(item))
             rootItem->appendChild(item);
     }
@@ -515,6 +531,20 @@ void TransferViewModel::updateParents(){
 
     emit layoutChanged();
 }
+
+void TransferViewModel::handleShowTranferedFilesOnlyState(int checkState){
+
+    switch (checkState){
+        case Qt::Unchecked : {
+            showTranferedFilesOnly = false;
+            break;
+        };
+        case Qt::Checked : {
+            showTranferedFilesOnly = true;
+            break;
+        };
+    };
+};
 
 void TransferViewModel::updateParent(TransferViewItem *p){
     if (!p || p->childCount() < 1 || p == rootItem)

--- a/eiskaltdcpp-qt/src/TransferViewModel.h
+++ b/eiskaltdcpp-qt/src/TransferViewModel.h
@@ -151,6 +151,9 @@ public Q_SLOTS:
     /** Just resort*/
     virtual void sort() { sort(sortColumn, sortOrder); }
 
+    // method to hide/show ulesess transfer info
+    void handleShowTranferedFilesOnlyState(int checkState);
+
 private:
     inline QString      vstr(const QVariant &var) { return var.toString(); }
     inline int          vint(const QVariant &var) { return var.toInt(); }
@@ -176,4 +179,6 @@ private:
     bool iconsScaled;
     /** */
     QSize iconsSize;
+
+    bool showTranferedFilesOnly;
 };

--- a/eiskaltdcpp-qt/ui/UITransferView.ui
+++ b/eiskaltdcpp-qt/ui/UITransferView.ui
@@ -57,6 +57,13 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="checkBox_showTranferedFilesOnly">
+     <property name="text">
+      <string>Show only transfered files</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
This patch allows to hide useless information in TransferView (i.e. "File list" and empty lines) and show only names of transfered files. Take a look on it!