### PR TITLE
Transfer view patch

### DIFF
--- a/eiskaltdcpp-qt/src/TransferView.cpp
+++ b/eiskaltdcpp-qt/src/TransferView.cpp
@@ -38,7 +38,7 @@
 #include <QFileInfo>
 #include <QDir>
 
-TransferView::Menu::Menu():
+TransferView::Menu::Menu(bool showTransferedFilesOnly):
         menu(NULL),
         selectedColumn(0)
 {
@@ -95,17 +95,7 @@ TransferView::Menu::Menu():
 
     QAction *show_only_transfered_files = new QAction(tr("Show only transfered files"), menu);
     show_only_transfered_files->setCheckable(true);
-    show_only_transfered_files->setChecked(false);
-
-
-    //connect (show_only_transfered_files, SIGNAL(changed()), this, SLOT(slotcheckState(int)));
-    //connect (show_only_transfered_files, SIGNAL(toggled (bool)), this, SLOT(slotcheckState(bool)));
-
-    connect(show_only_transfered_files, SIGNAL(toggled (bool)), [=](const bool& state)
-    {
-        show_only_transfered_files->setChecked(!state);
-    });
-
+    show_only_transfered_files->setChecked(showTransferedFilesOnly);
 
     actions.insert(browse, Browse);
     actions.insert(match, MatchQueue);
@@ -232,8 +222,6 @@ void TransferView::init(){
     connect(treeView_TRANSFERS, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(slotContextMenu(QPoint)));
     connect(treeView_TRANSFERS->header(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(slotHeaderMenu(QPoint)));
 
-    connect (checkBox_showTranferedFilesOnly, SIGNAL(stateChanged(int)), this, SLOT(slotcheckState(int)));
-
     connect(this, SIGNAL(coreDMRequesting(VarMap)),     model, SLOT(initTransfer(VarMap)), Qt::QueuedConnection);
     connect(this, SIGNAL(coreDMStarting(VarMap)),       model, SLOT(updateTransfer(VarMap)), Qt::QueuedConnection);
     connect(this, SIGNAL(coreDMTick(VarMap)),           model, SLOT(updateTransfer(VarMap)), Qt::QueuedConnection);
@@ -257,16 +245,6 @@ void TransferView::init(){
 
     load();
 }
-
-void TransferView::slotcheckState(int state){
-    model->handleShowTranferedFilesOnlyState(state);
-};
-
-void TransferView::show_only_transfered_files_slot_changed(bool state){
-    model->handleShowTranferedFilesOnlyState(state);
-};
-
-
 
 void TransferView::getFileList(const QString &cid, const QString &host){
     if (cid.isEmpty() || host.isEmpty())
@@ -451,7 +429,7 @@ void TransferView::slotContextMenu(const QPoint &){
         return;
 
     Menu::Action act;
-    Menu m;
+    Menu m(model->getShowTranferedFilesOnlyState());
 
     act = m.exec();
 
@@ -574,9 +552,7 @@ void TransferView::slotContextMenu(const QPoint &){
     }
     case Menu::showTransferedFieldsOnly:
     {
-
-        act.
-        //m.actions.find(Menu::showTransferedFieldsOnly).
+        model->setShowTranferedFilesOnlyState(!model->getShowTranferedFilesOnlyState());
         break;
     }
     case Menu::Close:

--- a/eiskaltdcpp-qt/src/TransferView.cpp
+++ b/eiskaltdcpp-qt/src/TransferView.cpp
@@ -216,6 +216,8 @@ void TransferView::init(){
     connect(treeView_TRANSFERS, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(slotContextMenu(QPoint)));
     connect(treeView_TRANSFERS->header(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(slotHeaderMenu(QPoint)));
 
+    connect (checkBox_showTranferedFilesOnly, SIGNAL(stateChanged(int)), this, SLOT(slotcheckState(int)));
+
     connect(this, SIGNAL(coreDMRequesting(VarMap)),     model, SLOT(initTransfer(VarMap)), Qt::QueuedConnection);
     connect(this, SIGNAL(coreDMStarting(VarMap)),       model, SLOT(updateTransfer(VarMap)), Qt::QueuedConnection);
     connect(this, SIGNAL(coreDMTick(VarMap)),           model, SLOT(updateTransfer(VarMap)), Qt::QueuedConnection);
@@ -239,6 +241,10 @@ void TransferView::init(){
 
     load();
 }
+
+void TransferView::slotcheckState(int state){
+    model->handleShowTranferedFilesOnlyState(state);
+};
 
 void TransferView::getFileList(const QString &cid, const QString &host){
     if (cid.isEmpty() || host.isEmpty())

--- a/eiskaltdcpp-qt/src/TransferView.cpp
+++ b/eiskaltdcpp-qt/src/TransferView.cpp
@@ -93,6 +93,20 @@ TransferView::Menu::Menu():
     QAction *close = new QAction(tr("Close connection(s)"), menu);
     close->setIcon(WU->getPixmap(WulforUtil::eiCONNECT_NO));
 
+    QAction *show_only_transfered_files = new QAction(tr("Show only transfered files"), menu);
+    show_only_transfered_files->setCheckable(true);
+    show_only_transfered_files->setChecked(false);
+
+
+    //connect (show_only_transfered_files, SIGNAL(changed()), this, SLOT(slotcheckState(int)));
+    //connect (show_only_transfered_files, SIGNAL(toggled (bool)), this, SLOT(slotcheckState(bool)));
+
+    connect(show_only_transfered_files, SIGNAL(toggled (bool)), [=](const bool& state)
+    {
+        show_only_transfered_files->setChecked(!state);
+    });
+
+
     actions.insert(browse, Browse);
     actions.insert(match, MatchQueue);
     actions.insert(send_pm, SendPM);
@@ -102,6 +116,7 @@ TransferView::Menu::Menu():
     actions.insert(force, Force);
     actions.insert(close, Close);
     actions.insert(search, SearchAlternates);
+    actions.insert(show_only_transfered_files, showTransferedFieldsOnly);
 
     menu->addActions(QList<QAction*>() << browse
                                        << search
@@ -115,6 +130,7 @@ TransferView::Menu::Menu():
                                        << sep3
                                        << force
                                        << close
+                                       << show_only_transfered_files
                                        );
 }
 
@@ -245,6 +261,12 @@ void TransferView::init(){
 void TransferView::slotcheckState(int state){
     model->handleShowTranferedFilesOnlyState(state);
 };
+
+void TransferView::show_only_transfered_files_slot_changed(bool state){
+    model->handleShowTranferedFilesOnlyState(state);
+};
+
+
 
 void TransferView::getFileList(const QString &cid, const QString &host){
     if (cid.isEmpty() || host.isEmpty())
@@ -548,6 +570,13 @@ void TransferView::slotContextMenu(const QPoint &){
         for (const auto &i : items)
             forceAttempt(i->cid);
 
+        break;
+    }
+    case Menu::showTransferedFieldsOnly:
+    {
+
+        act.
+        //m.actions.find(Menu::showTransferedFieldsOnly).
         break;
     }
     case Menu::Close:

--- a/eiskaltdcpp-qt/src/TransferView.h
+++ b/eiskaltdcpp-qt/src/TransferView.h
@@ -148,6 +148,7 @@ private Q_SLOTS:
     void slotContextMenu(const QPoint&);
     void slotHeaderMenu(const QPoint&);
     void downloadComplete(QString);
+    void slotcheckState(int);
     \
 private:
     TransferView(QWidget* = NULL);

--- a/eiskaltdcpp-qt/src/TransferView.h
+++ b/eiskaltdcpp-qt/src/TransferView.h
@@ -63,7 +63,7 @@ public:
         None
     };
 
-    Menu();
+    Menu(bool);
     virtual ~Menu();
 
     Action exec();
@@ -149,8 +149,6 @@ private Q_SLOTS:
     void slotContextMenu(const QPoint&);
     void slotHeaderMenu(const QPoint&);
     void downloadComplete(QString);
-    void slotcheckState(int);
-    void show_only_transfered_files_slot_changed(bool);
 
 private:
     TransferView(QWidget* = NULL);

--- a/eiskaltdcpp-qt/src/TransferView.h
+++ b/eiskaltdcpp-qt/src/TransferView.h
@@ -59,6 +59,7 @@ public:
         RemoveFromQueue,
         Force,
         Close,
+        showTransferedFieldsOnly,
         None
     };
 
@@ -149,7 +150,8 @@ private Q_SLOTS:
     void slotHeaderMenu(const QPoint&);
     void downloadComplete(QString);
     void slotcheckState(int);
-    \
+    void show_only_transfered_files_slot_changed(bool);
+
 private:
     TransferView(QWidget* = NULL);
     virtual ~TransferView();

--- a/eiskaltdcpp-qt/src/TransferViewModel.cpp
+++ b/eiskaltdcpp-qt/src/TransferViewModel.cpp
@@ -360,6 +360,13 @@ void TransferViewModel::addConnection(const VarMap &params){
 
     transfer_hash.insertMulti(item->cid, item);
 
+    if (showTranferedFilesOnly){
+        if (vstr(params["FNAME"]).isEmpty() || (tr("File list") == params["FNAME"]) ){
+            return;
+        };
+    };
+
+
     if (!to)
         rootItem->appendChild(item);
     else
@@ -391,7 +398,16 @@ void TransferViewModel::updateTransfer(const VarMap &params){
     item->fail = vbol(params["FAIL"]);
     item->tth = vstr(params["TTH"]);
 
+
+
     if (!vbol(params["DOWN"])){
+
+        if (showTranferedFilesOnly){
+            if (vstr(params["FNAME"]).isEmpty() || (tr("File list") == params["FNAME"]) ){
+                return;
+            };
+        };
+
         if (!rootItem->childItems.contains(item))
             rootItem->appendChild(item);
     }
@@ -515,6 +531,20 @@ void TransferViewModel::updateParents(){
 
     emit layoutChanged();
 }
+
+void TransferViewModel::handleShowTranferedFilesOnlyState(int checkState){
+
+    switch (checkState){
+        case Qt::Unchecked : {
+            showTranferedFilesOnly = false;
+            break;
+        };
+        case Qt::Checked : {
+            showTranferedFilesOnly = true;
+            break;
+        };
+    };
+};
 
 void TransferViewModel::updateParent(TransferViewItem *p){
     if (!p || p->childCount() < 1 || p == rootItem)

--- a/eiskaltdcpp-qt/src/TransferViewModel.cpp
+++ b/eiskaltdcpp-qt/src/TransferViewModel.cpp
@@ -46,7 +46,7 @@
 #include <set>
 
 TransferViewModel::TransferViewModel(QObject *parent)
-    : QAbstractItemModel(parent), iconsScaled(false)
+    : QAbstractItemModel(parent), iconsScaled(false), showTranferedFilesOnly(false)
 {
     QList<QVariant> rootData;
     rootData << tr("Users") << tr("Speed") << tr("Status") << tr("Flags") << tr("Size")
@@ -532,22 +532,12 @@ void TransferViewModel::updateParents(){
     emit layoutChanged();
 }
 
-void TransferViewModel::handleShowTranferedFilesOnlyState(int checkState){
-
-    switch (checkState){
-        case Qt::Unchecked : {
-            showTranferedFilesOnly = false;
-            break;
-        };
-        case Qt::Checked : {
-            showTranferedFilesOnly = true;
-            break;
-        };
-    };
+void TransferViewModel::setShowTranferedFilesOnlyState(bool state){
+    showTranferedFilesOnly = state;
 };
 
-void TransferViewModel::handleShowTranferedFilesOnlyState(bool state){
-    showTranferedFilesOnly = state;
+bool TransferViewModel::getShowTranferedFilesOnlyState(){
+    return showTranferedFilesOnly;
 };
 
 void TransferViewModel::updateParent(TransferViewItem *p){

--- a/eiskaltdcpp-qt/src/TransferViewModel.cpp
+++ b/eiskaltdcpp-qt/src/TransferViewModel.cpp
@@ -546,6 +546,10 @@ void TransferViewModel::handleShowTranferedFilesOnlyState(int checkState){
     };
 };
 
+void TransferViewModel::handleShowTranferedFilesOnlyState(bool state){
+    showTranferedFilesOnly = state;
+};
+
 void TransferViewModel::updateParent(TransferViewItem *p){
     if (!p || p->childCount() < 1 || p == rootItem)
         return;

--- a/eiskaltdcpp-qt/src/TransferViewModel.h
+++ b/eiskaltdcpp-qt/src/TransferViewModel.h
@@ -153,6 +153,7 @@ public Q_SLOTS:
 
     // method to hide/show ulesess transfer info
     void handleShowTranferedFilesOnlyState(int checkState);
+    void handleShowTranferedFilesOnlyState(bool state);
 
 private:
     inline QString      vstr(const QVariant &var) { return var.toString(); }

--- a/eiskaltdcpp-qt/src/TransferViewModel.h
+++ b/eiskaltdcpp-qt/src/TransferViewModel.h
@@ -151,6 +151,9 @@ public Q_SLOTS:
     /** Just resort*/
     virtual void sort() { sort(sortColumn, sortOrder); }
 
+    // method to hide/show ulesess transfer info
+    void handleShowTranferedFilesOnlyState(int checkState);
+
 private:
     inline QString      vstr(const QVariant &var) { return var.toString(); }
     inline int          vint(const QVariant &var) { return var.toInt(); }
@@ -176,4 +179,6 @@ private:
     bool iconsScaled;
     /** */
     QSize iconsSize;
+
+    bool showTranferedFilesOnly;
 };

--- a/eiskaltdcpp-qt/src/TransferViewModel.h
+++ b/eiskaltdcpp-qt/src/TransferViewModel.h
@@ -152,8 +152,8 @@ public Q_SLOTS:
     virtual void sort() { sort(sortColumn, sortOrder); }
 
     // method to hide/show ulesess transfer info
-    void handleShowTranferedFilesOnlyState(int checkState);
-    void handleShowTranferedFilesOnlyState(bool state);
+    void setShowTranferedFilesOnlyState (bool state);
+    bool getShowTranferedFilesOnlyState ();
 
 private:
     inline QString      vstr(const QVariant &var) { return var.toString(); }

--- a/eiskaltdcpp-qt/ui/UITransferView.ui
+++ b/eiskaltdcpp-qt/ui/UITransferView.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>93</width>
-    <height>93</height>
+    <width>205</width>
+    <height>114</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -54,13 +54,6 @@
      </property>
      <property name="animated">
       <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QCheckBox" name="checkBox_showTranferedFilesOnly">
-     <property name="text">
-      <string>Show only transfered files</string>
      </property>
     </widget>
    </item>

--- a/eiskaltdcpp-qt/ui/UITransferView.ui
+++ b/eiskaltdcpp-qt/ui/UITransferView.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>205</width>
-    <height>114</height>
+    <width>93</width>
+    <height>93</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/eiskaltdcpp-qt/ui/UITransferView.ui
+++ b/eiskaltdcpp-qt/ui/UITransferView.ui
@@ -57,6 +57,13 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="checkBox_showTranferedFilesOnly">
+     <property name="text">
+      <string>Show only transfered files</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
This patch allows to hide useless information in TransferView (i.e. "File list" and empty lines) and show only names of transfered files. Take a look on it!
Here separate branch for it. 