### PR TITLE
Add adc, adcs, dchub protocols handling information in .desktop files

### DIFF
--- a/eiskaltdcpp-gtk/eiskaltdcpp-gtk.desktop
+++ b/eiskaltdcpp-gtk/eiskaltdcpp-gtk.desktop
@@ -15,5 +15,5 @@ Comment[be]=Паздяляйцеся файламі праз сетку DC++
 Categories=Network;FileTransfer;P2P;Qt;
 GenericName[ru_RU]=Клиент сетей DC++
 GenericName[be_BY]=Кліент сеткі DC++
-MimeType=x-scheme-handler/magnet;
+MimeType=x-scheme-handler/magnet;x-scheme-handler/dchub;x-scheme-handler/adc;x-scheme-handler/adcs;
 Keywords=FileSharing;Chat;p2p;DirectConnect;ADC;DHT;

--- a/eiskaltdcpp-qt/eiskaltdcpp-qt.desktop
+++ b/eiskaltdcpp-qt/eiskaltdcpp-qt.desktop
@@ -15,5 +15,5 @@ Comment[be]=Паздяляйцеся файламі праз сетку DC++
 Categories=Network;FileTransfer;P2P;Qt;
 GenericName[ru_RU]=Клиент сетей DC++
 GenericName[be_BY]=Кліент сеткі DC++
-MimeType=x-scheme-handler/magnet;
+MimeType=x-scheme-handler/magnet;x-scheme-handler/dchub;x-scheme-handler/adc;x-scheme-handler/adcs;
 Keywords=FileSharing;Chat;p2p;DirectConnect;ADC;DHT;


### PR DESCRIPTION
Не смотря на то что eiskaltdcpp обрабатывает ссылки на хабы, эта информация отсутствует в .desktop файлах, посему система не знает что есть приложения для обработки этих ссылок.