### PR TITLE
Tooltips for favorite hubs. Load first pubhubs list on startup

### DIFF
--- a/eiskaltdcpp-qt/src/AutoToolTip.cpp
+++ b/eiskaltdcpp-qt/src/AutoToolTip.cpp
@@ -1,0 +1,52 @@
+/***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 3 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+/***
+* Origin: http://www.mimec.org/node/337
+*/
+
+#include "AutoToolTip.h"
+
+#include <QtCore>
+#include <QTextDocument>
+#include <QToolTip>
+
+AutoToolTipDelegate::AutoToolTipDelegate(QObject *parent): QStyledItemDelegate(parent) {}
+AutoToolTipDelegate::~AutoToolTipDelegate() {}
+
+bool AutoToolTipDelegate::helpEvent(QHelpEvent* e, QAbstractItemView* view,
+    const QStyleOptionViewItem& option, const QModelIndex& index)
+{
+    if (!e || !view)
+        return false;
+
+    if (e->type() == QEvent::ToolTip) {
+        QRect rect = view->visualRect(index);
+        QSize size = sizeHint(option, index);
+
+        if (rect.width() < size.width()) {
+            QVariant tooltip = index.data(Qt::DisplayRole);
+            if ( tooltip.canConvert<QString>() ) {
+                QToolTip::showText(e->globalPos(),
+#if QT_VERSION >= 0x050000
+                                   QString("<div>%1</div>").arg(tooltip.toString().toHtmlEscaped()),
+#else
+                                   QString("<div>%1</div>").arg(Qt::escape(tooltip.toString())),
+#endif
+                                   view);
+                return true;
+            }
+        }
+        if (!QStyledItemDelegate::helpEvent(e, view, option, index))
+            QToolTip::hideText();
+        return true;
+    }
+
+    return QStyledItemDelegate::helpEvent(e, view, option, index);
+}

--- a/eiskaltdcpp-qt/src/AutoToolTip.h
+++ b/eiskaltdcpp-qt/src/AutoToolTip.h
@@ -1,0 +1,29 @@
+/***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 3 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+/***
+* Origin: http://www.mimec.org/node/337
+*/
+
+#pragma once
+
+#include <QStyledItemDelegate>
+#include <QHelpEvent>
+#include <QAbstractItemView>
+
+class AutoToolTipDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+public:
+    AutoToolTipDelegate(QObject* parent);
+    ~AutoToolTipDelegate();
+
+public slots:
+    bool helpEvent(QHelpEvent* e, QAbstractItemView* view, const QStyleOptionViewItem& option, const QModelIndex& index);
+};

--- a/eiskaltdcpp-qt/src/PublicHubs.cpp
+++ b/eiskaltdcpp-qt/src/PublicHubs.cpp
@@ -10,6 +10,7 @@
 #include "PublicHubs.h"
 #include "MainWindow.h"
 #include "WulforSettings.h"
+#include "AutoToolTip.h"
 
 #include <QApplication>
 #include <QClipboard>
@@ -29,6 +30,7 @@ PublicHubs::PublicHubs(QWidget *parent) :
     model = new PublicHubModel();
 
     treeView->setModel(model);
+    treeView->setItemDelegate(new AutoToolTipDelegate(treeView));
     treeView->header()->restoreState(WVGET(WS_PUBLICHUBS_STATE, QByteArray()).toByteArray());
 
     lineEdit_FILTER->installEventFilter(this);
@@ -75,6 +77,8 @@ PublicHubs::PublicHubs(QWidget *parent) :
     connect(WulforSettings::getInstance(), SIGNAL(strValueChanged(QString,QString)), this, SLOT(slotSettingsChanged(QString,QString)));
     
     ArenaWidget::setState( ArenaWidget::Flags(ArenaWidget::state() | ArenaWidget::Singleton | ArenaWidget::Hidden) );
+    if (comboBox_HUBS->count())
+        slotHubChanged(comboBox_HUBS->currentIndex());
 }
 
 PublicHubs::~PublicHubs(){


### PR DESCRIPTION
Небольшие улучшения для списка публичных хабов.

1) Если имя/описание/адрес не влазять в грид - показать тултип с соответствующим именем/описанием/адресом.
Код позаимствован отсюда: http://www.mimec.org/node/337
2) Автоматически загружать первый список при старте.
Сейчас для того чтоб получить список необходимо изменить выбор в комбобоксе.