### PR TITLE
update mpris now_plyaing

### DIFF
--- a/data/examples/mpris_now_playing.en_US.sh
+++ b/data/examples/mpris_now_playing.en_US.sh
@@ -19,51 +19,104 @@
 # For songbird: http://addons.songbirdnest.com/addon/1626
 # For clementine: Native since 0.3
 # For exaile: Plugin. See http://www.exaile.org/wiki/KDE_and_MPRIS_plugin
+# For deadbeef: Plugin: https://github.com/Serranya/deadbeef-mpris2-plugin
 #
 # See also:
 # http://xmms2.org/wiki/MPRIS
 # http://incise.org/mpris-remote.html
 
 
-PLAYERS="amarok audacious qmmp mpd xmms2 dragon vlc songbird clementine exaile"
-
-CONFIG_FILE="${HOME}/.config/eiskaltdc++/mpris_now_playing.conf"
+CONFIG_FILE="${HOME}/.config/eiskaltdc++/mpris_now_playing2.conf"
 
 METADATA_CALL="/Player org.freedesktop.MediaPlayer.GetMetadata"
+METADATA_CALL_V2="/org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Metadata"
+
+STATUS_CALL="/Player org.freedesktop.MediaPlayer.GetStatus"
+STATUS_CALL_V2="/org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.PlaybackStatus"
+
 PLAYER=''
 declare -A tag
+declare -A paused
 
-# Trying to detect mpris compatible player and get info.
-for P in ${PLAYERS}; do
-    DBUS="$(qdbus | grep "org.mpris.${P}" | awk '{print $1}')"
-    if [[ "${DBUS}" && $(qdbus "${DBUS}" ${METADATA_CALL} 2>/dev/null) ]]
-    then
-        METAINFO="$(qdbus "${DBUS}" ${METADATA_CALL} 2>/dev/null)"
-        PLAYER="${P}"
-        for i in album artist genre title; do
-            tag[${i}]="$(echo "${METAINFO}" | sed -e "/^${i}: / !d" -e "s/^${i}: //")"
-        done
-        # Works only for local files:
-        LOCATION="$(echo "${METAINFO}" | sed -e '/^location: file:\/\// !d' -e 's/location: file:\/\///' | sed -n -e's/%\([0-9A-F][0-9A-F]\)/\\x\1/g' -e's/+/ /g' -e's/.*/echo -e "&"/g' -ep | "${SHELL}")"
-    fi
+QDBUS=$(which qdbus 2>/dev/null);
+if [ -z "$QDBUS" ]; then
+	QDBUS=$(which qdbus-qt5 2>/dev/null);
+fi
+if [ -z "$QDBUS" ]; then
+	echo "/me is missing qdbus or qdbus-qt5... :(";
+	exit 0;
+fi
+
+
+DBUS_COLLECTION=$(${QDBUS} | grep "org.mpris.");
+
+for app in $DBUS_COLLECTION; do
+	IS_MPRIS2=$(echo $app | grep "MediaPlayer2" | grep -v "grep" | wc -l);
+	PLAYER=$(echo $app | sed -r "s/.+\.//g" );
+	if [ $IS_MPRIS2 -eq 0 ]; then
+		MCALL=$METADATA_CALL;
+		SCALL=$STATUS_CALL;
+		_AP="--literal";
+	else
+		MCALL=$METADATA_CALL_V2;
+		SCALL=$STATUS_CALL_V2;
+		_AP="";
+	fi
+	METAINFO="$(${QDBUS} "${app}" ${MCALL} 2>/dev/null)";
+	if [ -n "$METAINFO" ]; then
+		STATUS="$($QDBUS ${_AP} "${app}" ${SCALL} 2>/dev/null)";
+		if [ $IS_MPRIS2 -eq 0 ]; then
+			STATUS=$(echo $STATUS | sed -r -e "s/\\[Argument: \\(iiii\\) ([0-9]+), .+\\]/\\1/");
+			if [ "$STATUS" == "0" ]; then
+				STATUS="Playing";
+			else
+				STATUS="Paused";
+			fi
+		fi
+		for i in album artist genre title; do
+			tag[${i}]="$(echo "${METAINFO}" | sed -r -e "/^(xesam:)?${i}: / !d" -e "s/^(xesam:)?${i}: //")"
+		done
+		# Works only for local files:
+		tag["location"]="$(echo "${METAINFO}" | sed -r -e '/^(location|xesam:url): file:\/\// !d' -e 's/(location|xesam:url): file:\/\///' | sed -n -e's/%\([0-9A-F][0-9A-F]\)/\\x\1/g' -e's/+/ /g' -e's/.*/echo -e "&"/g' -ep | "${SHELL}")"
+		tag["player"]=$PLAYER;
+		if [ "$STATUS" == "Playing" ]; then
+			break;
+		else
+			for i in album artist genre title location player; do
+			paused[$i]=${tag[$i]};
+			done
+		fi
+	else
+		PLAYER="";
+		STATUS="";
+		tag["player"]="";
+	fi
 done
 
+# If last player was not playing - getting last paused player.
+if [ "$STATUS" != "Playing" ] && [ -n "${paused[player]}" ]; then
+	for i in album artist genre title location player; do
+		tag[$i]=${paused[$i]};
+	done
+fi;
+
+
 # Some beautiful names for players
-case ${PLAYER} in
+case ${tag["player"]} in
     amarok)
-        PLAYER="Amarok"
+        tag["player"]="Amarok"
         ;;
     audacious)
-        PLAYER="Audacious2"
+        tag["player"]="Audacious2"
         ;;
     dragon)
-        PLAYER="Dragon Player"
+        tag["player"]="Dragon Player"
         ;;
     vlc)
-        PLAYER="VLC"
+        tag["player"]="VLC"
         ;;
     clementine)
-        PLAYER="Clementine"
+        tag["player"]="Clementine"
         ;;
 esac
 
@@ -74,9 +127,9 @@ esac
 #
 # This is an example config for mpris_now_playing script
 #
-if [ "\${PLAYER}" ]
+if [ -n "\${tag[player]}" ];
 then
-    NOW_LISTENING_TO="/me is listening to \${tag[artist]} - \${tag[title]} (\${tag[album]}) via \${PLAYER} <magnet>\${LOCATION}</magnet>"
+    NOW_LISTENING_TO="/me is listening to \${tag[artist]} - \${tag[title]} (\${tag[album]}) via \${tag[player]} <magnet>\${tag[location]}</magnet>"
 else
     NOW_LISTENING_TO="/me is listening to mouse clicks"
 fi


### PR DESCRIPTION
Обновил скирипт для определения играемой музыки через mpris
Добавлена поддержка mpris v2
Добавлено определение наличия в системе qdbus или qdbus-qt5
Избавление от "зашитого" списка поддерживаемых плееров.
Сокращено кол-во вызовов qdbus
Более корректное определение играющего проигрывателя (если несколько одновременно отдают информацию об играемом треке)