### PR TITLE
Send IPv4-only address in UPNP request

### DIFF
--- a/dcpp/ConnectivityManager.cpp
+++ b/dcpp/ConnectivityManager.cpp
@@ -90,7 +90,7 @@ void ConnectivityManager::detectConnection() {
 
    autoDetected = true;
 
-   if (!Util::isPrivateIp(Util::getLocalIp())) {
+   if (!Util::isPrivateIp(Util::getLocalIp(AF_INET))) {
        SettingsManager::getInstance()->set(SettingsManager::INCOMING_CONNECTIONS, SettingsManager::INCOMING_DIRECT);
        log(_("Public IP address detected, selecting active mode with direct connection"));
        fire(ConnectivityManagerListener::Finished());

--- a/dcpp/Util.cpp
+++ b/dcpp/Util.cpp
@@ -704,7 +704,7 @@ string Util::formatExactSize(int64_t aBytes) {
 #endif
 }
 
-vector<string> Util::getLocalIPs() {
+vector<string> Util::getLocalIPs(unsigned short sa_family) {
     vector<string> addresses;
 
 #ifdef HAVE_IFADDRS_H
@@ -712,6 +712,9 @@ vector<string> Util::getLocalIPs() {
 
     if (getifaddrs(&ifap) == 0)
     {
+        bool ipv4 = (sa_family == AF_UNSPEC) || (sa_family == AF_INET);
+        bool ipv6 = (sa_family == AF_UNSPEC) || (sa_family == AF_INET6);
+
         for (struct ifaddrs *i = ifap; i != NULL; i = i->ifa_next)
         {
             struct sockaddr *sa = i->ifa_addr;
@@ -723,14 +726,14 @@ vector<string> Util::getLocalIPs() {
                 socklen_t len;
 
                 // IPv4 address
-                if (sa->sa_family == AF_INET)
+                if (ipv4 && (sa->sa_family == AF_INET))
                 {
                     struct sockaddr_in* sai = (struct sockaddr_in*)sa;
                     src = (void*) &(sai->sin_addr);
                     len = INET_ADDRSTRLEN;
                 }
                 // IPv6 address
-                else if (sa->sa_family == AF_INET6)
+                else if (ipv6 && (sa->sa_family == AF_INET6))
                 {
                     struct sockaddr_in6* sai6 = (struct sockaddr_in6*)sa;
                     src = (void*) &(sai6->sin6_addr);
@@ -752,9 +755,13 @@ vector<string> Util::getLocalIPs() {
 
     return addresses;
 }
-string Util::getLocalIp() {
+string Util::getLocalIp(unsigned short as_family) {
 #ifdef HAVE_IFADDRS_H
-    return getLocalIPs().empty() ? "0.0.0.0" : getLocalIPs()[0];
+    vector<string> addresses = getLocalIPs(as_family);
+    if (addresses.empty())
+        return (((as_family == AF_UNSPEC) || (as_family == AF_INET)) ? "0.0.0.0" : "::");
+
+    return addresses[0];
 #else
     string tmp;
 

--- a/dcpp/Util.h
+++ b/dcpp/Util.h
@@ -28,6 +28,7 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/socket.h>
 #include <unistd.h>
 #include <cstdlib>
 #include <vector>
@@ -403,8 +404,8 @@ public:
     }
 
     static string encodeURI(const string& /*aString*/, bool reverse = false);
-    static string getLocalIp();
-    static std::vector<string> getLocalIPs();
+    static string getLocalIp(unsigned short sa_family = AF_UNSPEC);
+    static std::vector<string> getLocalIPs(unsigned short sa_family = AF_UNSPEC);
     static bool isPrivateIp(string const& ip);
     static string formatAdditionalInfo(const std::string& aIp, bool sIp, bool sCC);
     /**

--- a/extra/upnpc.cpp
+++ b/extra/upnpc.cpp
@@ -63,7 +63,7 @@ bool UPnPc::add(const unsigned short port, const UPnP::Protocol protocol, const 
     const string port_ = Util::toString(port);
 
     return UPNP_AddPortMapping(urls.controlURL, data.first.servicetype, port_.c_str(), port_.c_str(),
-        Util::getLocalIp().c_str(), description.c_str(), protocols[protocol], NULL
+        Util::getLocalIp(AF_INET).c_str(), description.c_str(), protocols[protocol], NULL
 #if (MINIUPNPC_API_VERSION == 8 || defined(MINIUPNPC16))
                                                                                     , 0) == UPNPCOMMAND_SUCCESS;
 #else


### PR DESCRIPTION
Eiskaltdc++ sends first available local IP address in UPNP request.
If first available address is IPv6, miniupnpd sends the following error:
"Failed to convert hostname '<my-ipv6-address>' to ip address"
This error was reproduced on OS X 10.9/10.10, but possibly the issue can be reproduced on any OS.

eiskaltdc++ uses getifaddrs() function to get list of all host IP addresses. This function returns both IPv4 and IPv6 addresses. But eiskaltdc++ does not support IPv6 yet (master branch), so the fix is to use IPv4-only addresses in UPNP requests.

The fix details:
getLocalIPs() and getLocalIp() functions now accept address family as first argument. Caller function can specify which address family it requires: AF_INET for IPv4 addresses, AF_INET6 for IPv6 addresses, AF_UNSPEC (default value) for any addresses. Default behaviour of these functions was not changed. UPNP client calls getLocalIp(AF_INET) now to get IPv4 addresses only.

The fix was verified on OS X 10.10.