### PR TITLE
Transcode back nicknames in SearchResults for passive search

### DIFF
--- a/dcpp/ClientManager.cpp
+++ b/dcpp/ClientManager.cpp
@@ -488,7 +488,7 @@ void ClientManager::on(NmdcSearch, Client* aClient, const string& aSeeker, int a
                 const SearchResultPtr& sr = *i;
                 str += sr->toSR(*aClient);
                 str[str.length()-1] = 5;
-                str += name;
+                str += Text::fromUtf8(name, aClient->getEncoding());
                 str += '|';
             }
 


### PR DESCRIPTION
Проблема: если пассивный пользователь с не латинским ником что-то искал, то мы отправляли результат левому пользователю:
```
ConnDC - (172.16.6.228) [ ����� ] IN: $Search Hub:����� F?T?0?1?����$|
...
ConnDC - (172.16.6.228) [ Vovochka12 ] OUT: $Search Hub:����� F?T?0?1?����$|
...
ConnDC - (172.16.6.228) [ Vovochka12 ] IN: $SR Vovochka12 ���������� ������\���������� ������ - ���� � ������� ����.mp35835089 15/15TTH:YE6YIVH6VJAMSPUXT7FJXIGLRW4P2XCGISXF5VA (172.16.6.228:4111)Вовка|
```
Как видно из пример, ник оставался в UTF-8 после чего хаб не мог определить кому вернуть результат поиска.