### PR TITLE
Fix Magnet dialog behavior

### DIFF
--- a/eiskaltdcpp-qt/src/DownloadQueue.cpp
+++ b/eiskaltdcpp-qt/src/DownloadQueue.cpp
@@ -638,7 +638,7 @@ void DownloadQueue::slotContextMenu(const QPoint &){
 
                 if (!magnet.isEmpty()){
                     Magnet m(this);
-                    m.setLink(magnet);
+                    m.setLink(magnet, Magnet::MAGNET_ACTION_SHOW_UI);
                     m.exec();
                 }
             }

--- a/eiskaltdcpp-qt/src/Magnet.cpp
+++ b/eiskaltdcpp-qt/src/Magnet.cpp
@@ -46,6 +46,7 @@ Magnet::Magnet(QWidget *parent) :
     else {
         pushButton_DOWNLOAD->setToolTip(tr("Download file via auto search alternatives"));
     }
+    currentAction = (MagnetAction)WIGET(WI_DEF_MAGNET_ACTION);
 }
 
 Magnet::~Magnet() {}
@@ -76,12 +77,17 @@ void Magnet::showUI(const QString &name, const qulonglong &size, const QString &
 }
 
 void Magnet::setLink(const QString &link){
+    setLink(link, currentAction);
+}
+
+void Magnet::setLink(const QString &link, MagnetAction action){
     QString name = "", tth = "";
     int64_t size = 0;
 
     WulforUtil::splitMagnet(link, size, tth, name);
+    currentAction = action;
 
-    switch (WIGET(WI_DEF_MAGNET_ACTION)) {
+    switch (action) {
         case MAGNET_ACTION_SEARCH: // search
             search(name, size, tth);
             break;
@@ -105,6 +111,14 @@ void Magnet::setLink(const QString &link){
             showUI(name, size, tth);
         }
     }
+}
+
+int Magnet::exec() {
+    if (currentAction != MAGNET_ACTION_SHOW_UI){
+        accept();
+        return result();
+    }
+    return QDialog::exec();
 }
 
 void Magnet::search(const QString &file, const qulonglong &size, const QString &tth){

--- a/eiskaltdcpp-qt/src/Magnet.h
+++ b/eiskaltdcpp-qt/src/Magnet.h
@@ -26,13 +26,16 @@ public:
     explicit Magnet(QWidget *parent = 0);
     virtual ~Magnet();
 
-    void setLink(const QString&);
-    enum {
+    void setLink(const QString &);
+    enum MagnetAction {
       MAGNET_ACTION_SHOW_UI = 0,
       MAGNET_ACTION_SEARCH = 1,
       MAGNET_ACTION_DOWNLOAD = 2
     };
-
+    void setLink(const QString &, MagnetAction action);
+    virtual int exec();
+private:
+    MagnetAction currentAction;
 private slots:
     void search();
     void download();

--- a/eiskaltdcpp-qt/src/MainWindow.cpp
+++ b/eiskaltdcpp-qt/src/MainWindow.cpp
@@ -1834,9 +1834,7 @@ void MainWindow::parseCmdLine(const QStringList &args){
         if (arg.startsWith("magnet:?")){
             Magnet m(this);
             m.setLink(arg);
-            if (WIGET(WI_DEF_MAGNET_ACTION) == 0) {
-                m.exec();
-            }
+            m.exec();
         }
         else if (arg.startsWith("dchub://")){
             newHubFrame(arg, "");
@@ -2180,9 +2178,7 @@ void MainWindow::slotOpenMagnet(){
 
     if (result.startsWith("magnet:?")){
         Magnet m(this);
-
         m.setLink(result);
-
         m.exec();
     }
 }

--- a/eiskaltdcpp-qt/src/SearchFrame.cpp
+++ b/eiskaltdcpp-qt/src/SearchFrame.cpp
@@ -1360,7 +1360,7 @@ void SearchFrame::slotContextMenu(const QPoint &){
 
                     if (!magnet.isEmpty()){
                         Magnet m(this);
-                        m.setLink(magnet + "\n");
+                        m.setLink(magnet + "\n", Magnet::MAGNET_ACTION_SHOW_UI);
                         m.exec();
                     }
                 }

--- a/eiskaltdcpp-qt/src/ShareBrowser.cpp
+++ b/eiskaltdcpp-qt/src/ShareBrowser.cpp
@@ -958,7 +958,7 @@ void ShareBrowser::slotCustomContextMenu(const QPoint &){
 
                 if (!magnet.isEmpty()){
                     Magnet m(this);
-                    m.setLink(magnet + "\n");
+                    m.setLink(magnet + "\n", Magnet::MAGNET_ACTION_SHOW_UI);
                     m.exec();
                 }
             }

--- a/eiskaltdcpp-qt/src/WulforUtil.cpp
+++ b/eiskaltdcpp-qt/src/WulforUtil.cpp
@@ -740,9 +740,7 @@ bool WulforUtil::openUrl(const QString &url){
         Magnet *m = new Magnet(MainWindow::getInstance());
 
         m->setLink(magnet);
-        if (WIGET(WI_DEF_MAGNET_ACTION) == 0) {
-            m->exec();
-        }
+        m->exec();
 
         m->deleteLater();
     }


### PR DESCRIPTION
Do not show empty Magnet dialog on "Open magnet link" action when default action isn't "Ask".
Do not start searching/downloading on clicking "Properties of magnet" when default action Search or Download.