### PR TITLE
Add missing includes for std::istream.

### DIFF
--- a/json/jsoncpp/src/json_reader.cpp
+++ b/json/jsoncpp/src/json_reader.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <cassert>
 #include <cstring>
+#include <istream>
 #include <stdexcept>
 
 #if defined(_MSC_VER)  &&  _MSC_VER >= 1400 // VC++ 8.0


### PR DESCRIPTION
This fixes the following link errors:

../json/libjsoncpp.a(json_reader.cpp.o): In function `Json::Reader::parse(std::__1::basic_istream<char, std::__1::char_traits<char> >&, Json::Value&, bool)':
/var/tmp/usr/ports/net-p2p/eiskaltdcpp-daemon/work/eiskaltdcpp-2.2.10/json/jsoncpp/src/json_reader.cpp:(.text+0x3d7): undefined reference to`std::__1::basic_istream<char, std::__1::char_traits<char> >& std::__1::getline<char, std::__1::char_traits<char>, std::__1::allocator<char> >(std::__1::basic_istream<char, std::__1::char_t  its<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&, char)'
c++: error: linker command failed with exit code 1 (use -v to see invocation)
