### PR TITLE
fix issue 363: eiskaltdcpp-qt don't quit in Qt5

### DIFF
--- a/eiskaltdcpp-qt/src/MainWindow.cpp
+++ b/eiskaltdcpp-qt/src/MainWindow.cpp
@@ -390,6 +390,9 @@ void MainWindow::closeEvent(QCloseEvent *c_e){
     if (ConnectionManager::getInstance())
         ConnectionManager::getInstance()->disconnect();
 
+    if (Notification::getInstance())
+        Notify->enableTray(false);
+
     d->arena->hide();
     d->arena->setWidget(NULL);
 


### PR DESCRIPTION
With Qt5.7.1, when the tray icon is enabled, the main window does not close. With Qt4.8, everything is fine, even if the icon is displayed.
So, can't close the application normally.

To solve this problem, I added code to force disable tray when exiting.
This don't affect the saved settings and allows to normally use the application with the tray enabled in Qt5.