### PR TITLE
Fix typo that breaks the handhsake

### DIFF
--- a/dcpp/NmdcHub.cpp
+++ b/dcpp/NmdcHub.cpp
@@ -625,7 +625,7 @@ void NmdcHub::onLine(const string& aLine) noexcept {
                 StringList feat = {
                     "UserCommand",
                     "NoGetINFO",
-                    "NoHello"
+                    "NoHello",
                     "UserIP2",
                     "TTHSearch",
                     "ZPipe0"


### PR DESCRIPTION
Fix typo introduced in https://github.com/eiskaltdcpp/eiskaltdcpp/commit/daab31b4e99f2a4e2ff2fe36afc03caf55c07fa6 that breaks the handshake. The hub sees a single `NoHelloUserIP2` feature instead of two separate ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eiskaltdcpp/eiskaltdcpp/398)
<!-- Reviewable:end -->
