### PR TITLE
Switch ALPN based on expected protocol

### DIFF
--- a/dcpp/AdcHub.cpp
+++ b/dcpp/AdcHub.cpp
@@ -61,7 +61,7 @@ const string AdcHub::DHT0_SUPPORT("ADDHT0");
 const vector<StringList> AdcHub::searchExts;
 
 AdcHub::AdcHub(const string& aHubURL, bool secure) :
-    Client(aHubURL, '\n', secure), oldPassword(false), sid(0) {
+    Client(aHubURL, '\n', secure, Socket::PROTO_ADC), oldPassword(false), sid(0) {
     TimerManager::getInstance()->addListener(this);
 }
 

--- a/dcpp/BufferedSocket.cpp
+++ b/dcpp/BufferedSocket.cpp
@@ -100,14 +100,14 @@ void BufferedSocket::accept(const Socket& srv, bool secure, bool allowUntrusted)
     addTask(ACCEPTED, 0);
 }
 
-void BufferedSocket::connect(const string& aAddress, const string& aPort, bool secure, bool allowUntrusted, bool proxy, const string& expKP) {
-    connect(aAddress, aPort, Util::emptyString, NAT_NONE, secure, allowUntrusted, proxy, expKP);
+void BufferedSocket::connect(const string& aAddress, const string& aPort, bool secure, bool allowUntrusted, bool proxy, int proto, const string& expKP) {
+    connect(aAddress, aPort, Util::emptyString, NAT_NONE, secure, allowUntrusted, proxy, proto, expKP);
 }
 
-void BufferedSocket::connect(const string& aAddress, const string& aPort, const string& localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, const string& expKP) {
+void BufferedSocket::connect(const string& aAddress, const string& aPort, const string& localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, int proto, const string& expKP) {
     (void)expKP;
     dcdebug("BufferedSocket::connect() %p\n", (void*)this);
-    std::unique_ptr<Socket> s(secure ? (natRole == NAT_SERVER ? CryptoManager::getInstance()->getServerSocket(allowUntrusted) : CryptoManager::getInstance()->getClientSocket(allowUntrusted)) : new Socket);
+    std::unique_ptr<Socket> s(secure ? (natRole == NAT_SERVER ? CryptoManager::getInstance()->getServerSocket(allowUntrusted) : CryptoManager::getInstance()->getClientSocket(allowUntrusted, proto)) : new Socket);
 
     s->create();
     setSocket(move(s));

--- a/dcpp/BufferedSocket.cpp
+++ b/dcpp/BufferedSocket.cpp
@@ -100,11 +100,11 @@ void BufferedSocket::accept(const Socket& srv, bool secure, bool allowUntrusted)
     addTask(ACCEPTED, 0);
 }
 
-void BufferedSocket::connect(const string& aAddress, const string& aPort, bool secure, bool allowUntrusted, bool proxy, int proto, const string& expKP) {
+void BufferedSocket::connect(const string& aAddress, const string& aPort, bool secure, bool allowUntrusted, bool proxy, Socket::Protocol proto, const string& expKP) {
     connect(aAddress, aPort, Util::emptyString, NAT_NONE, secure, allowUntrusted, proxy, proto, expKP);
 }
 
-void BufferedSocket::connect(const string& aAddress, const string& aPort, const string& localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, int proto, const string& expKP) {
+void BufferedSocket::connect(const string& aAddress, const string& aPort, const string& localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, Socket::Protocol proto, const string& expKP) {
     (void)expKP;
     dcdebug("BufferedSocket::connect() %p\n", (void*)this);
     std::unique_ptr<Socket> s(secure ? (natRole == NAT_SERVER ? CryptoManager::getInstance()->getServerSocket(allowUntrusted) : CryptoManager::getInstance()->getClientSocket(allowUntrusted, proto)) : new Socket);

--- a/dcpp/BufferedSocket.h
+++ b/dcpp/BufferedSocket.h
@@ -74,8 +74,8 @@ public:
     }
 
     void accept(const Socket& srv, bool secure, bool allowUntrusted);
-    void connect(const string& aAddress, const string& aPort, bool secure, bool allowUntrusted, bool proxy, int proto, const string& expKP = Util::emptyString);
-    void connect(const string& aAddress, const string& aPort, const string& localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, int proto, const string& expKP = Util::emptyString);
+    void connect(const string& aAddress, const string& aPort, bool secure, bool allowUntrusted, bool proxy, Socket::Protocol proto, const string& expKP = Util::emptyString);
+    void connect(const string& aAddress, const string& aPort, const string& localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, Socket::Protocol proto, const string& expKP = Util::emptyString);
 
     /** Sets data mode for aBytes bytes. Must be called within onLine. */
     void setDataMode(int64_t aBytes = -1) { mode = MODE_DATA; dataBytes = aBytes; }

--- a/dcpp/BufferedSocket.h
+++ b/dcpp/BufferedSocket.h
@@ -74,8 +74,8 @@ public:
     }
 
     void accept(const Socket& srv, bool secure, bool allowUntrusted);
-    void connect(const string& aAddress, const string& aPort, bool secure, bool allowUntrusted, bool proxy, const string& expKP = Util::emptyString);
-    void connect(const string& aAddress, const string& aPort, const string& localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, const string& expKP = Util::emptyString);
+    void connect(const string& aAddress, const string& aPort, bool secure, bool allowUntrusted, bool proxy, int proto, const string& expKP = Util::emptyString);
+    void connect(const string& aAddress, const string& aPort, const string& localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, int proto, const string& expKP = Util::emptyString);
 
     /** Sets data mode for aBytes bytes. Must be called within onLine. */
     void setDataMode(int64_t aBytes = -1) { mode = MODE_DATA; dataBytes = aBytes; }

--- a/dcpp/Client.cpp
+++ b/dcpp/Client.cpp
@@ -32,7 +32,7 @@ namespace dcpp {
 
 Client::Counts Client::counts;
 
-Client::Client(const string& hubURL, char separator_, bool secure_, int proto_) :
+Client::Client(const string& hubURL, char separator_, bool secure_, Socket::Protocol proto_) :
     myIdentity(ClientManager::getInstance()->getMe(), 0),
     reconnDelay(120), lastActivity(GET_TICK()), registered(false), autoReconnect(false),
     encoding(Text::hubDefaultCharset), state(STATE_DISCONNECTED), sock(0),

--- a/dcpp/Client.cpp
+++ b/dcpp/Client.cpp
@@ -32,11 +32,11 @@ namespace dcpp {
 
 Client::Counts Client::counts;
 
-Client::Client(const string& hubURL, char separator_, bool secure_) :
+Client::Client(const string& hubURL, char separator_, bool secure_, int proto_) :
     myIdentity(ClientManager::getInstance()->getMe(), 0),
     reconnDelay(120), lastActivity(GET_TICK()), registered(false), autoReconnect(false),
     encoding(Text::hubDefaultCharset), state(STATE_DISCONNECTED), sock(0),
-    hubUrl(hubURL), separator(separator_),
+    hubUrl(hubURL), separator(separator_), proto(proto_),
     secure(secure_), countType(COUNT_UNCOUNTED)
 {
     string file, proto, query, fragment;
@@ -134,7 +134,7 @@ void Client::connect() {
     try {
         sock = BufferedSocket::getSocket(separator);
         sock->addListener(this);
-        sock->connect(address, port, secure, BOOLSETTING(ALLOW_UNTRUSTED_HUBS), true);
+        sock->connect(address, port, secure, BOOLSETTING(ALLOW_UNTRUSTED_HUBS), true, proto);
     } catch(const Exception& e) {
         shutdown();
         /// @todo at this point, this hub instance is completely useless

--- a/dcpp/Client.h
+++ b/dcpp/Client.h
@@ -163,7 +163,7 @@ public:
     void reloadSettings(bool updateNick);
 protected:
     friend class ClientManager;
-    Client(const string& hubURL, char separator, bool secure_);
+    Client(const string& hubURL, char separator, bool secure_, int proto_);
     virtual ~Client();
     struct Counts {
     private:
@@ -227,6 +227,7 @@ private:
     string port;
     string externalIP;
     char separator;
+    int  proto;
     bool secure;
     CountType countType;
 };

--- a/dcpp/Client.h
+++ b/dcpp/Client.h
@@ -163,7 +163,7 @@ public:
     void reloadSettings(bool updateNick);
 protected:
     friend class ClientManager;
-    Client(const string& hubURL, char separator, bool secure_, int proto_);
+    Client(const string& hubURL, char separator, bool secure_, Socket::Protocol proto_);
     virtual ~Client();
     struct Counts {
     private:
@@ -227,7 +227,7 @@ private:
     string port;
     string externalIP;
     char separator;
-    int  proto;
+    Socket::Protocol proto;
     bool secure;
     CountType countType;
 };

--- a/dcpp/CryptoManager.cpp
+++ b/dcpp/CryptoManager.cpp
@@ -41,13 +41,6 @@ static const char ciphersuites[] =
         "AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:AES128-SHA"
         "!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK";
 
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
-static const unsigned char alpn_protos[] = {
-	3, 'a', 'd', 'c',
-	4, 'n', 'm', 'd', 'c',
-};
-#endif
-
 CryptoManager::CryptoManager()
     :
       certsLoaded(false),
@@ -157,10 +150,6 @@ CryptoManager::CryptoManager()
         SSL_CTX_set_verify(clientContext, SSL_VERIFY_NONE, 0);
         SSL_CTX_set_verify(clientVerContext, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
         SSL_CTX_set_verify(serverVerContext, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, 0);
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
-        SSL_CTX_set_alpn_protos(clientContext, alpn_protos, sizeof(alpn_protos));
-        SSL_CTX_set_alpn_protos(clientVerContext, alpn_protos, sizeof(alpn_protos));
-#endif
     }
 }
 
@@ -402,11 +391,11 @@ void CryptoManager::loadKeyprint(const string& file) noexcept {
     keyprint = ssl::X509_digest(x509, EVP_sha256());
 }
 
-SSLSocket* CryptoManager::getClientSocket(bool allowUntrusted) {
-    return new SSLSocket(allowUntrusted ? clientContext : clientVerContext);
+SSLSocket* CryptoManager::getClientSocket(bool allowUntrusted, int proto) {
+    return new SSLSocket(allowUntrusted ? clientContext : clientVerContext, proto);
 }
 SSLSocket* CryptoManager::getServerSocket(bool allowUntrusted) {
-    return new SSLSocket(allowUntrusted ? serverContext : serverVerContext);
+    return new SSLSocket(allowUntrusted ? serverContext : serverVerContext, Socket::PROTO_DEFAULT);
 }
 
 

--- a/dcpp/CryptoManager.cpp
+++ b/dcpp/CryptoManager.cpp
@@ -391,7 +391,7 @@ void CryptoManager::loadKeyprint(const string& file) noexcept {
     keyprint = ssl::X509_digest(x509, EVP_sha256());
 }
 
-SSLSocket* CryptoManager::getClientSocket(bool allowUntrusted, int proto) {
+SSLSocket* CryptoManager::getClientSocket(bool allowUntrusted, Socket::Protocol proto) {
     return new SSLSocket(allowUntrusted ? clientContext : clientVerContext, proto);
 }
 SSLSocket* CryptoManager::getServerSocket(bool allowUntrusted) {

--- a/dcpp/CryptoManager.h
+++ b/dcpp/CryptoManager.h
@@ -43,7 +43,7 @@ public:
 
     void decodeBZ2(const uint8_t* is, size_t sz, string& os);
 
-    SSLSocket* getClientSocket(bool allowUntrusted, int proto);
+    SSLSocket* getClientSocket(bool allowUntrusted, Socket::Protocol proto);
     SSLSocket* getServerSocket(bool allowUntrusted);
 
     void loadCertificates() noexcept;

--- a/dcpp/CryptoManager.h
+++ b/dcpp/CryptoManager.h
@@ -43,7 +43,7 @@ public:
 
     void decodeBZ2(const uint8_t* is, size_t sz, string& os);
 
-    SSLSocket* getClientSocket(bool allowUntrusted);
+    SSLSocket* getClientSocket(bool allowUntrusted, int proto);
     SSLSocket* getServerSocket(bool allowUntrusted);
 
     void loadCertificates() noexcept;

--- a/dcpp/HttpConnection.cpp
+++ b/dcpp/HttpConnection.cpp
@@ -134,7 +134,7 @@ void HttpConnection::prepareRequest(RequestType type) {
 
     socket->addListener(this);
     try {
-        socket->connect(server, port, (proto == "https"), true, false);
+        socket->connect(server, port, (proto == "https"), true, false, Socket::PROTO_DEFAULT);
     } catch(const Exception& e) {
         connState = CONN_FAILED;
         fire(HttpConnectionListener::Failed(), this, str(dcpp::dcpp_fmt("%1% (%2%)") % e.getError() % url));

--- a/dcpp/NmdcHub.cpp
+++ b/dcpp/NmdcHub.cpp
@@ -38,7 +38,7 @@
 namespace dcpp {
 
 NmdcHub::NmdcHub(const string& aHubURL, bool secure) :
-    Client(aHubURL, '|', secure),
+    Client(aHubURL, '|', secure, Socket::PROTO_NMDC),
     supportFlags(0),
     lastUpdate(0)
 {

--- a/dcpp/SSLSocket.cpp
+++ b/dcpp/SSLSocket.cpp
@@ -27,7 +27,16 @@
 
 namespace dcpp {
 
-SSLSocket::SSLSocket(SSL_CTX* context) : ctx(context), ssl(0) {
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+static const unsigned char alpn_protos_nmdc[] = {
+	4, 'n', 'm', 'd', 'c',
+};
+static const unsigned char alpn_protos_adc[] = {
+	3, 'a', 'd', 'c',
+};
+#endif
+
+SSLSocket::SSLSocket(SSL_CTX* context, int proto) : ctx(context), ssl(0), nextProto(proto) {
 
 }
 
@@ -55,6 +64,14 @@ bool SSLSocket::waitConnected(uint32_t millis) {
 
         checkSSL(SSL_set_fd(ssl, sock));
     }
+
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+    if (nextProto == Socket::PROTO_NMDC) {
+        SSL_set_alpn_protos(ssl, alpn_protos_nmdc, sizeof(alpn_protos_nmdc));
+    } else if (nextProto == Socket::PROTO_ADC) {
+        SSL_set_alpn_protos(ssl, alpn_protos_adc, sizeof(alpn_protos_adc));
+    }
+#endif
 
     if(SSL_is_init_finished(ssl)) {
         return true;

--- a/dcpp/SSLSocket.cpp
+++ b/dcpp/SSLSocket.cpp
@@ -36,7 +36,7 @@ static const unsigned char alpn_protos_adc[] = {
 };
 #endif
 
-SSLSocket::SSLSocket(SSL_CTX* context, int proto) : ctx(context), ssl(0), nextProto(proto) {
+SSLSocket::SSLSocket(SSL_CTX* context, Socket::Protocol proto) : ctx(context), ssl(0), nextProto(proto) {
 
 }
 

--- a/dcpp/SSLSocket.h
+++ b/dcpp/SSLSocket.h
@@ -71,12 +71,13 @@ public:
 private:
     friend class CryptoManager;
 
-    SSLSocket(SSL_CTX* context);
+    SSLSocket(SSL_CTX* context, int proto);
     SSLSocket(const SSLSocket&);
     SSLSocket& operator=(const SSLSocket&);
 
     SSL_CTX* ctx;
     ssl::SSL ssl;
+    int nextProto;
 
     int checkSSL(int ret);
     bool waitWant(int ret, uint32_t millis);

--- a/dcpp/SSLSocket.h
+++ b/dcpp/SSLSocket.h
@@ -71,13 +71,13 @@ public:
 private:
     friend class CryptoManager;
 
-    SSLSocket(SSL_CTX* context, int proto);
+    SSLSocket(SSL_CTX* context, Socket::Protocol proto);
     SSLSocket(const SSLSocket&);
     SSLSocket& operator=(const SSLSocket&);
 
     SSL_CTX* ctx;
     ssl::SSL ssl;
-    int nextProto;
+    Socket::Protocol nextProto;
 
     int checkSSL(int ret);
     bool waitWant(int ret, uint32_t millis);

--- a/dcpp/Socket.cpp
+++ b/dcpp/Socket.cpp
@@ -736,7 +736,7 @@ string Socket::getLocalPort() noexcept {
     return Util::emptyString;
 }
 
-int Socket::getNextProtocol() noexcept {
+Socket::Protocol Socket::getNextProtocol() noexcept {
     return proto;
 }
 

--- a/dcpp/Socket.h
+++ b/dcpp/Socket.h
@@ -71,7 +71,7 @@ public:
         TYPE_UDP
     };
 
-    enum {
+    enum Protocol {
         PROTO_DEFAULT = 0,
         PROTO_NMDC = 1,
         PROTO_ADC = 2
@@ -149,7 +149,7 @@ public:
     string getLocalIp() noexcept;
     string getLocalPort() noexcept;
 
-    int getNextProtocol() noexcept;
+    Protocol getNextProtocol() noexcept;
 
     // Low level interface
     virtual void create(int aType = TYPE_TCP);
@@ -178,7 +178,7 @@ public:
 protected:
     int type;
     bool connected;
-    int proto;
+    Protocol proto;
 
     class Stats {
     public:

--- a/dcpp/UserConnection.cpp
+++ b/dcpp/UserConnection.cpp
@@ -166,7 +166,7 @@ void UserConnection::connect(const string& aServer, const string& aPort, const s
     port = aPort;
     socket = BufferedSocket::getSocket(0);
     socket->addListener(this);
-    socket->connect(aServer, aPort, localPort, natRole, isSet(FLAG_SECURE), BOOLSETTING(ALLOW_UNTRUSTED_CLIENTS), true);
+    socket->connect(aServer, aPort, localPort, natRole, isSet(FLAG_SECURE), BOOLSETTING(ALLOW_UNTRUSTED_CLIENTS), true, Socket::PROTO_DEFAULT);
 }
 
 void UserConnection::accept(const Socket& aServer) {


### PR DESCRIPTION
The initial implementation of ALPN was sending both protocols during the handshake:
```
adc, nmdc
```
This works well for most hubs since they only expect a single protocol and intersection with server-supported protocols always leads to a single protocol.

However, this doesn't work with hybrid hubs that support both protocols and do a real ALPN negotiation. ADCS works well since it's specified as a preferred protocol during ALPN, but it fails for NMDCS, because the negotiation selects ADC while the client still expects NMDC (according to URI scheme). 

This PR fixes the issue by switching ALPN protocol to the one expected by the client. After the change, it will only advertise one protocol depending on the URI scheme.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eiskaltdcpp/eiskaltdcpp/406)
<!-- Reviewable:end -->
