### PR TITLE
Use url generated by fromLocalFile in openFile

### DIFF
--- a/eiskaltdcpp-qt/src/FinishedTransfers.h
+++ b/eiskaltdcpp-qt/src/FinishedTransfers.h
@@ -396,12 +396,7 @@ private:
                 file = path + QDir::separator() + files.first();
         }
 
-        if (file.startsWith(QChar('/')))
-            file.prepend("file://");
-        else
-            file.prepend("file:///");
-
-        QDesktopServices::openUrl(QUrl(file));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(file));
     }
 
     void slotItemDoubleClicked(const QModelIndex &proxyIndex){


### PR DESCRIPTION
Fixes #419

	modified:   eiskaltdcpp-qt/src/FinishedTransfers.h

Earlier unencoded file path was passed on to QUrl constructor in
openFile. This caused incorrect parsing because characters such as `#`
are valid in file path, but has special meaning in URL.

Now, we use `fromLocalFile` method provided by QUrl instead of QString
constructor of QUrl.