### PR TITLE
Remove duplicate hublist

### DIFF
--- a/dcpp/SettingsManager.cpp
+++ b/dcpp/SettingsManager.cpp
@@ -170,7 +170,6 @@ SettingsManager::SettingsManager()
                "https://dchublist.ru/hublist.xml.bz2;"
                "https://hublist.eu/hublist.xml.bz2;"
                "https://dcnf.github.io/Hublist/hublist.xml.bz2;"
-               "https://dchublist.org/adchublist.xml.bz2;"
                );
     setDefault(DOWNLOAD_SLOTS, 3);
     setDefault(SKIPLIST_SHARE, "*.~*|*.*~");


### PR DESCRIPTION
https://dchublist.org/adchublist.xml.bz2 is already present in https://dchublist.org/hublist.xml.bz2