### PR TITLE
Allow to install uncompressed man pages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,10 @@ option (LOCAL_JSONCPP "Use local JsonCpp" ON)
 option (BUILD_STATIC "Static build (only for MS Windows and GNU/Linux)" OFF)
 option (INSTALL_QT_TRANSLATIONS "Install Qt internal translations" OFF)
 
+if (UNIX)
+    option (COMPRESS_MANPAGES "Compress the installed man pages" ON)
+endif ()
+
 if (UNIX AND NOT HAIKU)
     option (FORCE_XDG "Respect freedesktop.org standards" ON)
 endif ()

--- a/eiskaltdcpp-cli/CMakeLists.txt
+++ b/eiskaltdcpp-cli/CMakeLists.txt
@@ -10,12 +10,16 @@ if (USE_CLI_XMLRPC)
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
     if (UNIX)
-        execute_process (
-                OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-xmlrpc.1.gz
-                COMMAND "${GZIP_CMD}" -9
-                INPUT_FILE ${PROJECT_NAME}-xmlrpc.1
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
-        install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-xmlrpc.1.gz DESTINATION ${MAN_DIR})
+        if(COMPRESS_MANPAGES)
+            execute_process (
+                    OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-xmlrpc.1.gz
+                    COMMAND "${GZIP_CMD}" -9
+                    INPUT_FILE ${PROJECT_NAME}-xmlrpc.1
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
+            install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-xmlrpc.1.gz DESTINATION ${MAN_DIR})
+        else(COMPRESS_MANPAGES)
+            install (FILES ${PROJECT_NAME}-xmlrpc.1 DESTINATION ${MAN_DIR})
+        endif(COMPRESS_MANPAGES)
     endif (UNIX)
 endif ()
 
@@ -27,12 +31,16 @@ if (USE_CLI_JSONRPC)
         PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
     if (UNIX)
-        execute_process (
-                OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-jsonrpc.1.gz
-                COMMAND "${GZIP_CMD}" -9
-                INPUT_FILE ${PROJECT_NAME}-jsonrpc.1
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
-        install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-jsonrpc.1.gz DESTINATION ${MAN_DIR})
+        if(COMPRESS_MANPAGES)
+            execute_process (
+                    OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-jsonrpc.1.gz
+                    COMMAND "${GZIP_CMD}" -9
+                    INPUT_FILE ${PROJECT_NAME}-jsonrpc.1
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/)
+            install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-jsonrpc.1.gz DESTINATION ${MAN_DIR})
+        else(COMPRESS_MANPAGES)
+            install (FILES ${PROJECT_NAME}-jsonrpc.1 DESTINATION ${MAN_DIR})
+        endif(COMPRESS_MANPAGES)
     endif (UNIX)
 endif ()
 

--- a/eiskaltdcpp-daemon/CMakeLists.txt
+++ b/eiskaltdcpp-daemon/CMakeLists.txt
@@ -87,12 +87,16 @@ install (TARGETS ${PROJECT_NAME}
     BUNDLE DESTINATION ${BUNDLEDIR})
 
 if (UNIX AND NOT APPLE AND NOT HAIKU)
-    execute_process (
-                OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz
-                COMMAND "${GZIP_CMD}" -9
-                INPUT_FILE ${PROJECT_NAME}.1
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/)
-    install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz DESTINATION ${MAN_DIR})
+    if(COMPRESS_MANPAGES)
+        execute_process (
+                    OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz
+                    COMMAND "${GZIP_CMD}" -9
+                    INPUT_FILE ${PROJECT_NAME}.1
+                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/)
+        install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz DESTINATION ${MAN_DIR})
+    else(COMPRESS_MANPAGES)
+        install (FILES ${PROJECT_NAME}.1 DESTINATION ${MAN_DIR})
+    endif(COMPRESS_MANPAGES)
 endif ()
 
 if (WIN32 OR APPLE)

--- a/eiskaltdcpp-gtk/CMakeLists.txt
+++ b/eiskaltdcpp-gtk/CMakeLists.txt
@@ -118,11 +118,15 @@ else (APPLE)
 endif (APPLE)
 
 if (UNIX)
-    execute_process (OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz
-                     COMMAND "${GZIP_CMD}" -9
-                     INPUT_FILE ${PROJECT_NAME}.1
-                     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/)
-    install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz DESTINATION ${MAN_DIR})
+    if(COMPRESS_MANPAGES)
+        execute_process (OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz
+                         COMMAND "${GZIP_CMD}" -9
+                         INPUT_FILE ${PROJECT_NAME}.1
+                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/)
+        install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz DESTINATION ${MAN_DIR})
+    else(COMPRESS_MANPAGES)
+        install (FILES ${PROJECT_NAME}.1 DESTINATION ${MAN_DIR})
+    endif(COMPRESS_MANPAGES)
 endif (UNIX)
 
 set_property (TARGET ${PROJECT_NAME} PROPERTY OUTPUT_NAME "${PROJECT_NAME}")

--- a/eiskaltdcpp-qt/CMakeLists.txt
+++ b/eiskaltdcpp-qt/CMakeLists.txt
@@ -220,11 +220,15 @@ add_custom_target(${PROJECT_NAME}_tr ALL DEPENDS ${TRANSLATIONS_BINARY})
 set (DEFAULT_QRC_FILE ${PROJECT_SOURCE_DIR}/icons/appl/default/default.qrc)
 
 if (UNIX AND NOT APPLE AND NOT HAIKU)
-    execute_process (OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz
-                     COMMAND "${GZIP_CMD}" -9
-                     INPUT_FILE ${PROJECT_NAME}.1
-                     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/)
-    install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz DESTINATION ${MAN_DIR})
+    if(COMPRESS_MANPAGES)
+        execute_process (OUTPUT_FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz
+                         COMMAND "${GZIP_CMD}" -9
+                         INPUT_FILE ${PROJECT_NAME}.1
+                         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/)
+        install (FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.1.gz DESTINATION ${MAN_DIR})
+    else(COMPRESS_MANPAGES)
+        install (FILES ${PROJECT_NAME}.1 DESTINATION ${MAN_DIR})
+    endif(COMPRESS_MANPAGES)
 endif ()
 
 if (WIN32 OR APPLE)


### PR DESCRIPTION
In certain systems like Gentoo based ones, it is considered a QA violation to install already compressed man pages. Instead make this specific behaviour configurable using a CMake option.