### PR TITLE
Add missing format.h include in the upnp mapping management code

### DIFF
--- a/dcpp/MappingManager.cpp
+++ b/dcpp/MappingManager.cpp
@@ -22,6 +22,7 @@
 #include "ConnectionManager.h"
 #include "SearchManager.h"
 #include "LogManager.h"
+#include "format.h"
 #include "version.h"
 #include "ConnectivityManager.h"
 #ifdef USE_MINIUPNP


### PR DESCRIPTION
This fixes compile-time issues. (Thanks juippis from Gentoo for finding and reporting this)