### PR TITLE
HashProgress.h: add missing <cstdint> include

### DIFF
--- a/eiskaltdcpp-qt/src/HashProgress.h
+++ b/eiskaltdcpp-qt/src/HashProgress.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <QDialog>
 #include <QTimer>
 #include <QLabel>


### PR DESCRIPTION
Fix building with gcc13