### PR TITLE
Minor fix to CLIENT_DATA_DIR for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ if (NOT SHARE_DIR)
 endif (NOT SHARE_DIR)
 
 if (APPLE)
-    set (CLIENT_DATA_DIR "${PROJECT_NAME_GLOBAL}.app/Contents/Resources/")
+    set (CLIENT_DATA_DIR "${PROJECT_NAME_GLOBAL}.app/Contents/Resources")
     set (CLIENT_DOCS_DIR "${CLIENT_DATA_DIR}/docs")
 elseif (WIN32)
     set (CLIENT_DATA_DIR "${SHARE_DIR}")


### PR DESCRIPTION
Currently `CLIENT_DATA_DIR` is set to `${PROJECT_NAME_GLOBAL}.app/Contents/Resources/`, and then every path which uses it has another / after it, so we get double //.
Fix this.