### PR TITLE
Update miniupnpc api to v18

### DIFF
--- a/extra/upnpc.cpp
+++ b/extra/upnpc.cpp
@@ -53,7 +53,11 @@ bool UPnPc::init()
     if (!devices)
         return false;
 
+#if (MINIUPNPC_API_VERSION >= 18)
+    bool ret = UPNP_GetValidIGD(devices, &urls, &data, nullptr, 0, nullptr, 0);
+#else
     bool ret = UPNP_GetValidIGD(devices, &urls, &data, nullptr, 0);
+#endif
 
     freeUPNPDevlist(devices);
 


### PR DESCRIPTION
`UPNP_GetValidIGD()` prototype has changed in API version 18.

https://github.com/miniupnp/miniupnp/commit/c0a50ce33e3b99ce8a96fd43049bb5b53ffac62f