### PR TITLE
Remove the adchublist from dchublist.org website

### DIFF
--- a/dcpp/SettingsManager.cpp
+++ b/dcpp/SettingsManager.cpp
@@ -168,7 +168,6 @@ SettingsManager::SettingsManager()
                "https://dchublist.biz/hublist.xml.bz2;"
                "https://dchublist.ru/hublist.xml.bz2;"
                "https://dcnf.github.io/Hublist/hublist.xml.bz2;"
-               "https://dchublist.org/adchublist.xml.bz2;"
                );
     setDefault(DOWNLOAD_SLOTS, 3);
     setDefault(SKIPLIST_SHARE, "*.~*|*.*~");


### PR DESCRIPTION
The list is already included in the first one (hublist)