### PR TITLE
fix: enable clean shutdown and re-initialization of dcpp singletons

### DIFF
--- a/dcpp/DCPlusPlus.cpp
+++ b/dcpp/DCPlusPlus.cpp
@@ -175,6 +175,8 @@ void shutdown() {
     TimerManager::deleteInstance();
     ResourceManager::deleteInstance();
 
+    Util::uninitialize();
+
 #ifdef _WIN32
     ::WSACleanup();
 #endif

--- a/dcpp/SearchManager.cpp
+++ b/dcpp/SearchManager.cpp
@@ -59,9 +59,7 @@ SearchManager::~SearchManager() {
     if(socket.get()) {
         stop = true;
         socket->disconnect();
-#ifdef _WIN32
         join();
-#endif
     }
 }
 

--- a/dcpp/SearchManager.h
+++ b/dcpp/SearchManager.h
@@ -99,6 +99,7 @@ private:
         void shutdown() {
             stop = true;
             s.signal();
+            join();
         }
         void addResult(const string& buf, const string& ip) {
             {

--- a/dcpp/Util.cpp
+++ b/dcpp/Util.cpp
@@ -164,9 +164,16 @@ static string getDownloadsPath(const string& def) {
 
 #endif // _WIN32
 
+static bool s_utilInitDone = false;
+
+void Util::uninitialize() {
+    for (auto& p : paths)
+        p.clear();
+    s_utilInitDone = false;
+}
+
 void Util::initialize(PathsMap pathOverrides) {
-    static bool initDone = false;
-    if (initDone)
+    if (s_utilInitDone)
         return;
 
     Text::initialize();
@@ -356,7 +363,7 @@ void Util::initialize(PathsMap pathOverrides) {
         }
     } catch(const FileException&) {
     }
-    initDone = true;
+    s_utilInitDone = true;
 }
 
 void Util::migrate(const string& file) {

--- a/dcpp/Util.h
+++ b/dcpp/Util.h
@@ -115,6 +115,7 @@ public:
 
     typedef std::map<Util::Paths, std::string> PathsMap;
     static void initialize(PathsMap pathOverrides = PathsMap());
+    static void uninitialize();
 
     /** Path of temporary storage */
     static string getTempPath();


### PR DESCRIPTION
Three issues prevented dcpp from being cleanly torn down and re-initialized:

1. SearchManager::~SearchManager() only called join() on Windows, leaving the search thread running on Linux/macOS after the object was destroyed. The UdpQueue inner thread had the same problem — shutdown() signaled stop but never joined, so ~Thread() would pthread_detach a still-running thread that could access freed memory.

2. Util::initialize() used a function-local 'static bool initDone' guard that could never be reset, making re-initialization impossible even after all singletons were properly destroyed.

3. dcpp::shutdown() destroyed all singletons but never called Util::uninitialize(), so paths and the init guard persisted.

Changes:
- SearchManager.cpp: call join() unconditionally (remove #ifdef _WIN32)
- SearchManager.h: add join() in UdpQueue::shutdown() after signaling stop
- Util.h/cpp: add uninitialize() that clears paths[] and resets the guard; replace function-local static with file-scope static
- DCPlusPlus.cpp: call Util::uninitialize() at end of shutdown()