### PR TITLE
Fix character range check in SimpleXMLReader

### DIFF
--- a/dcpp/SimpleXMLReader.cpp
+++ b/dcpp/SimpleXMLReader.cpp
@@ -340,7 +340,7 @@ bool SimpleXMLReader::declVersionNum() {
                 return true;
             }
 
-            if(!inRange(c, 0, 9)) {
+            if(!inRange(c, '0', '9')) {
                 return false;
             }
         }


### PR DESCRIPTION
The `inRange` function (line 32) does `c >= a && c <= b`. With parameters `0` and `9`, this accepts bytes 0x00-0x09 (NUL through TAB), while actual ASCII digit characters '0'-'9' are 0x30-0x39 and will cause the function to return `false`.