### PR TITLE
feat: modernize macOS launch, packaging, and security

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,37 @@
+name: macOS
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-14
+          - arch: x86_64
+            runner: macos-13
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install cmake ninja ccache qt@5 gettext openssl@3 aspell jsoncpp libidn2 lua miniupnpc pcre2
+      - name: Build app
+        run: |
+          export HOMEBREW_PREFIX="$(brew --prefix)"
+          macos/build-app.sh --arch "${{ matrix.arch }}" --no-package
+      - name: Verify app
+        run: |
+          app="dist/macos-${{ matrix.arch }}-release/EiskaltDC++.app"
+          file "$app/Contents/MacOS/EiskaltDC++"
+          codesign --verify --deep --strict "$app"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: EiskaltDC++-${{ matrix.arch }}
+          path: dist/macos-${{ matrix.arch }}-release/EiskaltDC++.app

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   HOMEBREW_NO_ENV_HINTS: 1
 
 jobs:
@@ -19,11 +18,20 @@ jobs:
             runner: macos-14
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           brew update
-          brew install cmake ninja ccache qt@5 gettext openssl@3 aspell jsoncpp libidn2 lua miniupnpc pcre2
+          deps=(cmake ninja ccache qt@5 gettext openssl@3 aspell jsoncpp libidn2 lua miniupnpc pcre2)
+          missing=()
+          for dep in "${deps[@]}"; do
+            brew list --formula "$dep" >/dev/null 2>&1 || missing+=("$dep")
+          done
+          if [[ "${#missing[@]}" -gt 0 ]]; then
+            # GitHub Actions turns Homebrew's harmless "Warning:" lines into annotations.
+            # Keep logs readable without hiding brew failures.
+            brew install "${missing[@]}" 2>&1 | sed 's/Warning:/Note:/g'
+          fi
       - name: Build app
         run: |
           export HOMEBREW_PREFIX="$(brew --prefix)"
@@ -33,7 +41,7 @@ jobs:
           app="dist/macos-${{ matrix.arch }}-release/EiskaltDC++.app"
           file "$app/Contents/MacOS/EiskaltDC++"
           codesign --verify --deep --strict "$app"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: EiskaltDC++-${{ matrix.arch }}
           path: dist/macos-${{ matrix.arch }}-release/EiskaltDC++.app

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  HOMEBREW_NO_ENV_HINTS: 1
+
 jobs:
   build:
     strategy:
@@ -13,8 +17,6 @@ jobs:
         include:
           - arch: arm64
             runner: macos-14
-          - arch: x86_64
-            runner: macos-13
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,54 @@
+{
+  "version": 4,
+  "cmakeMinimumRequired": { "major": 3, "minor": 23, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "macos-base-release",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_POLICY_VERSION_MINIMUM": "3.5",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/dist/${presetName}",
+        "USE_QT": "OFF",
+        "USE_QT5": "ON",
+        "USE_QT_SQLITE": "ON",
+        "USE_MINIUPNP": "ON",
+        "USE_ASPELL": "ON",
+        "USE_PROGRESS_BARS": "OFF",
+        "NO_UI_DAEMON": "OFF",
+        "JSONRPC_DAEMON": "OFF",
+        "PERL_REGEX": "ON",
+        "LUA_SCRIPT": "ON",
+        "WITH_SOUNDS": "ON",
+        "WITH_LUASCRIPTS": "ON",
+        "LOCAL_ASPELL_DATA": "OFF",
+        "LOCAL_JSONCPP": "OFF"
+      },
+      "environment": {
+        "CMAKE_PREFIX_PATH": "$env{HOMEBREW_PREFIX}/opt/qt@5;$env{HOMEBREW_PREFIX};$env{HOMEBREW_PREFIX}/opt/gettext;$env{HOMEBREW_PREFIX}/opt/openssl@3;$env{HOMEBREW_PREFIX}/opt/pcre2"
+      }
+    },
+    {
+      "name": "macos-arm64-release",
+      "inherits": "macos-base-release",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "arm64",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.0"
+      }
+    },
+    {
+      "name": "macos-x86_64-release",
+      "inherits": "macos-base-release",
+      "cacheVariables": {
+        "CMAKE_OSX_ARCHITECTURES": "x86_64",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "10.15"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "macos-arm64-release", "configurePreset": "macos-arm64-release" },
+    { "name": "macos-x86_64-release", "configurePreset": "macos-x86_64-release" }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -15,6 +15,7 @@
         "USE_QT5": "ON",
         "USE_QT_SQLITE": "ON",
         "USE_MINIUPNP": "ON",
+        "WITH_DHT": "OFF",
         "USE_ASPELL": "ON",
         "USE_PROGRESS_BARS": "OFF",
         "NO_UI_DAEMON": "OFF",

--- a/dcpp/AdcCommand.h
+++ b/dcpp/AdcCommand.h
@@ -84,7 +84,7 @@ public:
     static const char TYPE_HUB = 'H';
     static const char TYPE_UDP = 'U';
 
-#if defined(_WIN32) || defined(__i386__) || defined(__x86_64__) || defined(__alpha) || defined(__arm__)
+#if defined(_WIN32) || defined(__i386__) || defined(__x86_64__) || defined(__alpha) || defined(__arm__) || defined(__aarch64__)
 #define C(n, a, b, c) static const uint32_t CMD_##n = (((uint32_t)a) | (((uint32_t)b)<<8) | (((uint32_t)c)<<16)); typedef Type<CMD_##n> n
 #else
 #define C(n, a, b, c) static const uint32_t CMD_##n = ((((uint32_t)a)<<24) | (((uint32_t)b)<<16) | (((uint32_t)c)<<8)); typedef Type<CMD_##n> n

--- a/dcpp/CMakeLists.txt
+++ b/dcpp/CMakeLists.txt
@@ -15,6 +15,12 @@ if (NOT LUA_SCRIPT)
     list (REMOVE_ITEM dcpp_srcs ${PROJECT_SOURCE_DIR}/ScriptManager.cpp)
 endif (NOT LUA_SCRIPT)
 
+if (APPLE)
+    list (REMOVE_ITEM dcpp_srcs ${PROJECT_SOURCE_DIR}/PasswordStore.cpp)
+else (APPLE)
+    list (REMOVE_ITEM dcpp_srcs ${PROJECT_SOURCE_DIR}/PasswordStore_mac.cpp)
+endif (APPLE)
+
 include_directories (${PROJECT_BINARY_DIR}
                      ${BZIP2_INCLUDE_DIR}
                      ${ZLIB_INCLUDE_DIR}
@@ -46,7 +52,8 @@ if (NOT LINK)
 endif (NOT LINK)
 
 if (APPLE)
-    set (APPLE_LIBS "iconv")
+    find_library(SECURITY_LIBRARY Security)
+    set (APPLE_LIBS "iconv" ${SECURITY_LIBRARY})
 endif (APPLE)
 
 set (UPNP "extra")

--- a/dcpp/DCPlusPlus.cpp
+++ b/dcpp/DCPlusPlus.cpp
@@ -52,6 +52,10 @@
 namespace dcpp {
 
 void startup(void (*f)(void*, const string&), void* p) {
+    startup(f, p, StartupOptions());
+}
+
+void startup(void (*f)(void*, const string&), void* p, const StartupOptions& options) {
     // "Dedicated to the near-memory of Nev. Let's start remembering people while they're still alive."
     // Nev's great contribution to dc++
     while(1) break;
@@ -113,16 +117,20 @@ void startup(void (*f)(void*, const string&), void* p) {
 
     if(f != NULL)
         (*f)(p, _("Hash database"));
-    HashManager::getInstance()->startup();
+    if(!options.skipHashLoad) {
+        HashManager::getInstance()->startup();
+    }
     if(f != NULL)
         (*f)(p, _("Shared Files"));
-    const string XmlListFileName = Util::getPath(Util::PATH_USER_CONFIG) + "files.xml.bz2";
-    if(!Util::fileExists(XmlListFileName)) {
-        try {
-            File::copyFile(XmlListFileName + ".bak", XmlListFileName);
-        } catch(const FileException&) { }
+    if(!options.skipShareRefresh) {
+        const string XmlListFileName = Util::getPath(Util::PATH_USER_CONFIG) + "files.xml.bz2";
+        if(!Util::fileExists(XmlListFileName)) {
+            try {
+                File::copyFile(XmlListFileName + ".bak", XmlListFileName);
+            } catch(const FileException&) { }
+        }
+        ShareManager::getInstance()->refresh(true, false, !options.nonBlockingShareRefresh);
     }
-    ShareManager::getInstance()->refresh(true, false, true);
     if(f != NULL)
         (*f)(p, _("Download Queue"));
     QueueManager::getInstance()->loadQueue();

--- a/dcpp/DCPlusPlus.h
+++ b/dcpp/DCPlusPlus.h
@@ -24,7 +24,14 @@ namespace dcpp {
 
 using std::string;
 
+struct StartupOptions {
+    bool skipHashLoad = false;
+    bool skipShareRefresh = false;
+    bool nonBlockingShareRefresh = false;
+};
+
 extern void startup(void (*f)(void*, const string&), void* p);
+extern void startup(void (*f)(void*, const string&), void* p, const StartupOptions& options);
 extern void shutdown();
 
 } // namespace dcpp

--- a/dcpp/FavoriteManager.cpp
+++ b/dcpp/FavoriteManager.cpp
@@ -24,6 +24,7 @@
 #include "File.h"
 #include "FilteredFile.h"
 #include "HttpConnection.h"
+#include "PasswordStore.h"
 #include "SimpleXML.h"
 #include "StringTokenizer.h"
 #include "UserCommand.h"
@@ -334,7 +335,15 @@ void FavoriteManager::save() {
             xml.addChildAttrib("Connect", (*i)->getConnect());
             xml.addChildAttrib("Description", (*i)->getHubDescription());
             xml.addChildAttrib("Nick", (*i)->getNick(false));
+#if defined(__APPLE__)
+            if (PasswordStore::isAvailable() && PasswordStore::setHubPassword((*i)->getServer(), (*i)->getNick(false), (*i)->getPassword())) {
+                xml.addChildAttrib("PasswordStore", string("Keychain"));
+            } else {
+                xml.addChildAttrib("Password", (*i)->getPassword());
+            }
+#else
             xml.addChildAttrib("Password", (*i)->getPassword());
+#endif
             xml.addChildAttrib("Server", (*i)->getServer());
             xml.addChildAttrib("UserDescription", (*i)->getUserDescription());
             xml.addChildAttrib("Encoding", (*i)->getEncoding());
@@ -450,8 +459,21 @@ void FavoriteManager::load(SimpleXML& aXml) {
             e->setConnect(aXml.getBoolChildAttrib("Connect"));
             e->setHubDescription(aXml.getChildAttrib("Description"));
             e->setNick(aXml.getChildAttrib("Nick"));
-            e->setPassword(aXml.getChildAttrib("Password"));
+            const string legacyPassword = aXml.getChildAttrib("Password");
+            e->setPassword(legacyPassword);
             e->setServer(aXml.getChildAttrib("Server"));
+#if defined(__APPLE__)
+            if (PasswordStore::isAvailable()) {
+                string keychainPassword;
+                if (PasswordStore::getHubPassword(e->getServer(), e->getNick(false), keychainPassword)) {
+                    e->setPassword(keychainPassword);
+                    if (!legacyPassword.empty())
+                        needSave = true;
+                } else if (!legacyPassword.empty() && PasswordStore::setHubPassword(e->getServer(), e->getNick(false), legacyPassword)) {
+                    needSave = true;
+                }
+            }
+#endif
             e->setUserDescription(aXml.getChildAttrib("UserDescription"));
             e->setEncoding(aXml.getChildAttrib("Encoding"));
             e->setExternalIP(aXml.getChildAttrib("ExternalIP"));

--- a/dcpp/MappingManager.cpp
+++ b/dcpp/MappingManager.cpp
@@ -73,64 +73,71 @@ int MappingManager::run() {
     const string dht_port = dht::DHT::getInstance()->getPort();
 #endif
 
-    for(auto &i : impls) {
-        UPnP& impl = *i;
-
-        close(impl);
-
-        if(!impl.init()){
-            log(str(F_("Failed to initialize the %1% interface") % impl.getName()));
-            continue;
+    for(int attempt = 0; attempt < 2 && !opened; ++attempt) {
+        if(attempt > 0) {
+            log(_("Port mapping failed; retrying after a short delay..."));
+            Thread::sleep(3000);
         }
 
-        if(!conn_port.empty() && !impl.open(conn_port, UPnP::PROTOCOL_TCP, str(F_(APPNAME " Transfer Port (%1% TCP)") % conn_port))){
-            log(str(F_("The %1% interface has failed to map the %2% %3% port") % impl.getName() % "TCP" % conn_port));
-            continue;
-        }
+        for(auto &i : impls) {
+            UPnP& impl = *i;
 
-        if(!secure_port.empty() && !impl.open(secure_port, UPnP::PROTOCOL_TCP, str(F_(APPNAME " Encrypted Transfer Port (%1% TCP)") % secure_port))){
-            log(str(F_("The %1% interface has failed to map the %2% %3% port") % impl.getName() % "TLS" % secure_port));
-            continue;
-        }
+            close(impl);
 
-        if(!search_port.empty() && !impl.open(search_port, UPnP::PROTOCOL_UDP, str(F_(APPNAME " Search Port (%1% UDP)") % search_port))){
-            log(str(F_("The %1% interface has failed to map the %2% %3% port") % impl.getName() % "UDP" % search_port));
-            continue;
-        }
-#ifdef WITH_DHT
-        if(!dht_port.empty() && !impl.open(dht_port, UPnP::PROTOCOL_UDP, str(F_(APPNAME " DHT Port (%1% UDP)") % dht_port))){
-            log(str(F_("The %1% interface has failed to map the %2% %3% port") % impl.getName() % "UDP" % dht_port));
-            continue;
-        }
-#endif
-
-        opened = true;
-
-#ifdef WITH_DHT
-        if(!dht_port.empty())
-            log(str(F_("Successfully created port mappings (TCP: %1%, UDP: %2%, TLS: %3%, DHT: %4%), mapped using the %5% interface") % conn_port % search_port % secure_port % dht_port % impl.getName()));
-        else
-            log(str(F_("Successfully created port mappings (TCP: %1%, UDP: %2%, TLS: %3%), mapped using the %4% interface") % conn_port % search_port % secure_port % impl.getName()));
-#else
-        log(str(F_("Successfully created port mappings (TCP: %1%, UDP: %2%, TLS: %3%), mapped using the %4% interface") % conn_port % search_port % secure_port % impl.getName()));
-#endif
-
-        if(!BOOLSETTING(NO_IP_OVERRIDE)) {
-            // now lets configure the external IP (connect to me) address
-            string ExternalIP = impl.getExternalIP();
-            if(!ExternalIP.empty()) {
-                // woohoo, we got the external IP from the UPnP framework
-                SettingsManager::getInstance()->set(SettingsManager::EXTERNAL_IP, ExternalIP);
-            } else {
-                //:-( Looks like we have to rely on the user setting the external IP manually
-                // no need to do cleanup here because the mappings work
-                log(_("Failed to get external IP"));
+            if(!impl.init()){
+                log(str(F_("Failed to initialize the %1% interface") % impl.getName()));
+                continue;
             }
+
+            if(!conn_port.empty() && !impl.open(conn_port, UPnP::PROTOCOL_TCP, str(F_(APPNAME " Transfer Port (%1% TCP)") % conn_port))){
+                log(str(F_("The %1% interface has failed to map the %2% %3% port") % impl.getName() % "TCP" % conn_port));
+                continue;
+            }
+
+            if(!secure_port.empty() && !impl.open(secure_port, UPnP::PROTOCOL_TCP, str(F_(APPNAME " Encrypted Transfer Port (%1% TCP)") % secure_port))){
+                log(str(F_("The %1% interface has failed to map the %2% %3% port") % impl.getName() % "TLS" % secure_port));
+                continue;
+            }
+
+            if(!search_port.empty() && !impl.open(search_port, UPnP::PROTOCOL_UDP, str(F_(APPNAME " Search Port (%1% UDP)") % search_port))){
+                log(str(F_("The %1% interface has failed to map the %2% %3% port") % impl.getName() % "UDP" % search_port));
+                continue;
+            }
+#ifdef WITH_DHT
+            if(!dht_port.empty() && !impl.open(dht_port, UPnP::PROTOCOL_UDP, str(F_(APPNAME " DHT Port (%1% UDP)") % dht_port))){
+                log(str(F_("The %1% interface has failed to map the %2% %3% port") % impl.getName() % "UDP" % dht_port));
+                continue;
+            }
+#endif
+
+            opened = true;
+
+#ifdef WITH_DHT
+            if(!dht_port.empty())
+                log(str(F_("Successfully created port mappings (TCP: %1%, UDP: %2%, TLS: %3%, DHT: %4%), mapped using the %5% interface") % conn_port % search_port % secure_port % dht_port % impl.getName()));
+            else
+                log(str(F_("Successfully created port mappings (TCP: %1%, UDP: %2%, TLS: %3%), mapped using the %4% interface") % conn_port % search_port % secure_port % impl.getName()));
+#else
+            log(str(F_("Successfully created port mappings (TCP: %1%, UDP: %2%, TLS: %3%), mapped using the %4% interface") % conn_port % search_port % secure_port % impl.getName()));
+#endif
+
+            if(!BOOLSETTING(NO_IP_OVERRIDE)) {
+                // now lets configure the external IP (connect to me) address
+                string ExternalIP = impl.getExternalIP();
+                if(!ExternalIP.empty()) {
+                    // woohoo, we got the external IP from the UPnP framework
+                    SettingsManager::getInstance()->set(SettingsManager::EXTERNAL_IP, ExternalIP);
+                } else {
+                    //:-( Looks like we have to rely on the user setting the external IP manually
+                    // no need to do cleanup here because the mappings work
+                    log(_("Failed to get external IP"));
+                }
+            }
+
+            ConnectivityManager::getInstance()->mappingFinished(true);
+
+            break;
         }
-
-        ConnectivityManager::getInstance()->mappingFinished(true);
-
-        break;
     }
 
     if(!opened) {

--- a/dcpp/MappingManager.cpp
+++ b/dcpp/MappingManager.cpp
@@ -38,6 +38,7 @@ const uint64_t UPNP_REFRESH_INTERVAL = 60 * 60 * 1000ULL;
 
 MappingManager::MappingManager() :
     opened(false),
+    refreshing(false),
     portMapping(false),
     lastRefresh(0) {
     TimerManager::getInstance()->addListener(this);
@@ -70,6 +71,7 @@ bool MappingManager::refresh() {
         return false;
     }
 
+    refreshing = opened;
     start();
 
     return true;
@@ -91,6 +93,9 @@ int MappingManager::run() {
 #ifdef WITH_DHT
     const string dht_port = dht::DHT::getInstance()->getPort();
 #endif
+
+    const bool wasRefreshing = refreshing;
+    opened = false;
 
     for(int attempt = 0; attempt < 2 && !opened; ++attempt) {
         if(attempt > 0) {
@@ -153,17 +158,25 @@ int MappingManager::run() {
                 }
             }
 
-            ConnectivityManager::getInstance()->mappingFinished(true);
+            if(!wasRefreshing) {
+                ConnectivityManager::getInstance()->mappingFinished(true);
+            }
 
             break;
         }
     }
 
     if(!opened) {
-        log(_("Failed to create port mappings"));
-        ConnectivityManager::getInstance()->mappingFinished(false);
+        if(wasRefreshing) {
+            log(_("Failed to refresh port mappings; will retry later"));
+            opened = true;
+        } else {
+            log(_("Failed to create port mappings"));
+            ConnectivityManager::getInstance()->mappingFinished(false);
+        }
     }
     portMapping = false;
+    refreshing = false;
     lastRefresh = GET_TICK();
     return 0;
 }

--- a/dcpp/MappingManager.cpp
+++ b/dcpp/MappingManager.cpp
@@ -32,6 +32,21 @@
 #include "dht/DHT.h"
 #endif
 namespace dcpp {
+namespace {
+const uint64_t UPNP_REFRESH_INTERVAL = 60 * 60 * 1000ULL;
+}
+
+MappingManager::MappingManager() :
+    opened(false),
+    portMapping(false),
+    lastRefresh(0) {
+    TimerManager::getInstance()->addListener(this);
+}
+
+MappingManager::~MappingManager() noexcept {
+    TimerManager::getInstance()->removeListener(this);
+    join();
+}
 
 void MappingManager::addImplementation(UPnP* impl) {
     impls.push_back(std::unique_ptr<UPnP>(impl));
@@ -41,6 +56,10 @@ bool MappingManager::open() {
     if(opened)
         return false;
 
+    return refresh();
+}
+
+bool MappingManager::refresh() {
     if(impls.empty()) {
         log(_("No UPnP implementation available"));
         return false;
@@ -145,7 +164,15 @@ int MappingManager::run() {
         ConnectivityManager::getInstance()->mappingFinished(false);
     }
     portMapping = false;
+    lastRefresh = GET_TICK();
     return 0;
+}
+
+void MappingManager::on(TimerManagerListener::Minute, uint64_t aTick) noexcept {
+    if(opened && aTick - lastRefresh >= UPNP_REFRESH_INTERVAL) {
+        log(_("Refreshing UPnP port mappings..."));
+        refresh();
+    }
 }
 
 void MappingManager::close(UPnP& impl) {

--- a/dcpp/MappingManager.h
+++ b/dcpp/MappingManager.h
@@ -62,6 +62,7 @@ private:
     Impls impls;
 
     bool opened;
+    bool refreshing;
     Atomic<bool,memory_ordering_strong> portMapping;
     uint64_t lastRefresh;
 

--- a/dcpp/MappingManager.h
+++ b/dcpp/MappingManager.h
@@ -25,6 +25,7 @@
 #include "forward.h"
 #include "Singleton.h"
 #include "Thread.h"
+#include "TimerManager.h"
 #include "UPnP.h"
 
 namespace dcpp {
@@ -36,7 +37,8 @@ using std::vector;
 
 class MappingManager :
         public Singleton<MappingManager>,
-        private Thread
+        private Thread,
+        private TimerManagerListener
 {
 public:
     /**
@@ -48,6 +50,7 @@ public:
     void runMiniUPnP();
     void addImplementation(UPnP* impl);
     bool open();
+    bool refresh();
     void close();
 
     bool getOpened() const { return opened; }
@@ -60,11 +63,13 @@ private:
 
     bool opened;
     Atomic<bool,memory_ordering_strong> portMapping;
+    uint64_t lastRefresh;
 
-    MappingManager() : opened(false), portMapping(false) { }
-    virtual ~MappingManager() noexcept { join(); }
+    MappingManager();
+    virtual ~MappingManager() noexcept;
 
     int run();
+    void on(TimerManagerListener::Minute, uint64_t aTick) noexcept;
 
     void close(UPnP& impl);
     void log(const string& message);

--- a/dcpp/PasswordStore.cpp
+++ b/dcpp/PasswordStore.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 EiskaltDC++ developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "stdinc.h"
+#include "PasswordStore.h"
+
+namespace dcpp {
+
+bool PasswordStore::isAvailable() {
+    return false;
+}
+
+bool PasswordStore::getHubPassword(const std::string&, const std::string&, std::string&) {
+    return false;
+}
+
+bool PasswordStore::setHubPassword(const std::string&, const std::string&, const std::string&) {
+    return false;
+}
+
+bool PasswordStore::deleteHubPassword(const std::string&, const std::string&) {
+    return false;
+}
+
+} // namespace dcpp

--- a/dcpp/PasswordStore.h
+++ b/dcpp/PasswordStore.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2026 EiskaltDC++ developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace dcpp {
+
+class PasswordStore {
+public:
+    static bool isAvailable();
+    static bool getHubPassword(const std::string& server, const std::string& nick, std::string& password);
+    static bool setHubPassword(const std::string& server, const std::string& nick, const std::string& password);
+    static bool deleteHubPassword(const std::string& server, const std::string& nick);
+};
+
+} // namespace dcpp

--- a/dcpp/PasswordStore_mac.cpp
+++ b/dcpp/PasswordStore_mac.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 EiskaltDC++ developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "stdinc.h"
+#include "PasswordStore.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+
+namespace dcpp {
+namespace {
+
+const char* KEYCHAIN_SERVICE = "org.eiskaltdcpp.hub-password";
+
+CFStringRef makeString(const std::string& value) {
+    return CFStringCreateWithBytes(kCFAllocatorDefault,
+                                   reinterpret_cast<const UInt8*>(value.data()),
+                                   static_cast<CFIndex>(value.size()),
+                                   kCFStringEncodingUTF8,
+                                   false);
+}
+
+std::string accountForHub(const std::string& server, const std::string& nick) {
+    return server + "|" + nick;
+}
+
+class CFReleaseGuard {
+public:
+    explicit CFReleaseGuard(CFTypeRef value = nullptr) : value(value) { }
+    ~CFReleaseGuard() { if(value) CFRelease(value); }
+    CFTypeRef get() const { return value; }
+    CFMutableDictionaryRef mutableDictionary() const { return const_cast<CFMutableDictionaryRef>(static_cast<CFDictionaryRef>(value)); }
+    CFTypeRef* out() { return &value; }
+private:
+    CFTypeRef value;
+};
+
+CFMutableDictionaryRef createQuery(const std::string& server, const std::string& nick) {
+    CFMutableDictionaryRef query = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+                                                             &kCFTypeDictionaryKeyCallBacks,
+                                                             &kCFTypeDictionaryValueCallBacks);
+    if(!query)
+        return nullptr;
+
+    CFReleaseGuard service(makeString(KEYCHAIN_SERVICE));
+    CFReleaseGuard account(makeString(accountForHub(server, nick)));
+    if(!service.get() || !account.get()) {
+        CFRelease(query);
+        return nullptr;
+    }
+
+    CFDictionarySetValue(query, kSecClass, kSecClassGenericPassword);
+    CFDictionarySetValue(query, kSecAttrService, service.get());
+    CFDictionarySetValue(query, kSecAttrAccount, account.get());
+    return query;
+}
+
+} // namespace
+
+bool PasswordStore::isAvailable() {
+    return true;
+}
+
+bool PasswordStore::getHubPassword(const std::string& server, const std::string& nick, std::string& password) {
+    CFReleaseGuard query(createQuery(server, nick));
+    if(!query.get())
+        return false;
+
+    CFDictionarySetValue(query.mutableDictionary(), kSecReturnData, kCFBooleanTrue);
+    CFDictionarySetValue(query.mutableDictionary(), kSecMatchLimit, kSecMatchLimitOne);
+
+    CFReleaseGuard result;
+    OSStatus status = SecItemCopyMatching(static_cast<CFDictionaryRef>(query.get()), result.out());
+    if(status != errSecSuccess || !result.get())
+        return false;
+
+    CFDataRef data = static_cast<CFDataRef>(result.get());
+    password.assign(reinterpret_cast<const char*>(CFDataGetBytePtr(data)),
+                    static_cast<size_t>(CFDataGetLength(data)));
+    return true;
+}
+
+bool PasswordStore::setHubPassword(const std::string& server, const std::string& nick, const std::string& password) {
+    if(password.empty())
+        return deleteHubPassword(server, nick);
+
+    CFReleaseGuard query(createQuery(server, nick));
+    if(!query.get())
+        return false;
+
+    CFReleaseGuard data(CFDataCreate(kCFAllocatorDefault,
+                                     reinterpret_cast<const UInt8*>(password.data()),
+                                     static_cast<CFIndex>(password.size())));
+    if(!data.get())
+        return false;
+
+    CFMutableDictionaryRef attrs = CFDictionaryCreateMutable(kCFAllocatorDefault, 0,
+                                                             &kCFTypeDictionaryKeyCallBacks,
+                                                             &kCFTypeDictionaryValueCallBacks);
+    if(!attrs)
+        return false;
+    CFReleaseGuard attrsGuard(attrs);
+    CFDictionarySetValue(attrs, kSecValueData, data.get());
+
+    OSStatus status = SecItemUpdate(static_cast<CFDictionaryRef>(query.get()), attrs);
+    if(status == errSecSuccess)
+        return true;
+    if(status != errSecItemNotFound)
+        return false;
+
+    CFDictionarySetValue(query.mutableDictionary(), kSecValueData, data.get());
+    return SecItemAdd(static_cast<CFDictionaryRef>(query.get()), nullptr) == errSecSuccess;
+}
+
+bool PasswordStore::deleteHubPassword(const std::string& server, const std::string& nick) {
+    CFReleaseGuard query(createQuery(server, nick));
+    if(!query.get())
+        return false;
+
+    OSStatus status = SecItemDelete(static_cast<CFDictionaryRef>(query.get()));
+    return status == errSecSuccess || status == errSecItemNotFound;
+}
+
+} // namespace dcpp

--- a/dcpp/SettingsManager.cpp
+++ b/dcpp/SettingsManager.cpp
@@ -277,7 +277,7 @@ SettingsManager::SettingsManager()
     setDefault(HASH_BUFFER_PRIVATE, true);
     setDefault(RECONNECT_DELAY, 15);
     setDefault(DHT_PORT, 6250);
-    setDefault(USE_DHT, true);
+    setDefault(USE_DHT, false);
     setDefault(SEARCH_PASSIVE, false);
     setDefault(MAX_UPLOAD_SPEED_MAIN, 0);
     setDefault(MAX_DOWNLOAD_SPEED_MAIN, 0);

--- a/docs/macos-modernization.md
+++ b/docs/macos-modernization.md
@@ -1,0 +1,105 @@
+# Modern macOS modernization
+
+This branch modernizes EiskaltDC++ for current macOS releases while preserving the cross-platform Qt 5 application.
+
+## Phase 1: launch reliability
+
+Implemented:
+
+- Native macOS single-instance handling now uses `QLocalServer`/`QLocalSocket` as the liveness check instead of trusting stale Qt shared-memory files.
+- Stale local-server state is removed automatically with `QLocalServer::removeServer()`.
+- A second launch forwards URLs/arguments to the running instance immediately.
+- If the existing instance cannot be contacted, the new process continues startup instead of silently exiting.
+- Recovery startup flags:
+  - `--safe-mode` skips hash load, shared-file refresh, and autoconnect.
+  - `--skip-hash-load` skips HashIndex/HashData load and implies skipped share refresh.
+  - `--skip-share-refresh` skips the initial shared-files cache/refresh step.
+  - `--nonblocking-share-refresh` avoids blocking startup on a cold share scan.
+  - `--startup-timing` prints phase timings.
+
+Example:
+
+```sh
+/Applications/EiskaltDC++.app/Contents/MacOS/EiskaltDC++ --safe-mode --startup-timing
+```
+
+## Phase 2: build, packaging, CI
+
+Implemented:
+
+- `CMakePresets.json` for reproducible Homebrew-based macOS builds.
+- `macos/build-app.sh` for local arm64/x86_64 builds.
+- `macos/sign-and-notarize.sh` for Developer ID signing/notarization.
+- `macos/merge-universal-app.sh` for merging separately built thin apps into a universal app.
+- GitHub Actions workflow at `.github/workflows/macos.yml`.
+
+Local Apple Silicon build:
+
+```sh
+brew install cmake ninja ccache qt@5 gettext openssl@3 aspell jsoncpp libidn2 lua miniupnpc pcre2
+export HOMEBREW_PREFIX="$(brew --prefix)"
+macos/build-app.sh --arch arm64 --no-package
+open dist/macos-arm64-release/EiskaltDC++.app
+```
+
+Universal build note: Homebrew Qt/dependencies are usually thin per prefix/runner. A true universal app requires building arm64 and x86_64 apps separately, merging every Mach-O binary/framework/plugin with `lipo`, and re-signing.
+
+## Phase 3: macOS UX polish
+
+The app now has a better foundation for macOS UX:
+
+- URL/argument forwarding to the existing instance is immediate and no longer waits on shared-memory polling.
+- Safe-mode and timing flags provide user-facing recovery behavior for hung launches.
+- The packaged app is ad-hoc signed locally by `build-app.sh`; use `sign-and-notarize.sh` for public distribution.
+
+Recommended follow-up UI work:
+
+- Audit menus for standard macOS conventions (`Preferences…` on Cmd+, and app menu placement).
+- Audit dark-mode colors/icons and Retina assets.
+- Add native notification permission handling if Qt notifications are insufficient.
+
+## Phase 4: resilience
+
+Implemented:
+
+- Safe mode for broken configs and giant hash/share states.
+- Nonblocking share-refresh option.
+- Startup timing diagnostics for hash database, shared files, queue, users, main-window, icons, notifications, and show phases.
+
+Operational guidance:
+
+- Use `--startup-timing` to identify the slow startup phase.
+- Use `--safe-mode` to launch without touching the large hash/share state.
+- Use `--skip-share-refresh` when a configured `/Volumes/...` share is offline or very slow.
+
+Recommended follow-up engineering:
+
+- Move hash-index parsing to an asynchronous loaded-state model.
+- Add a GUI hash database repair/rebuild command.
+- Add an exportable diagnostic bundle with redacted paths/passwords.
+
+## Phase 5: security
+
+Implemented on macOS:
+
+- Favorite hub passwords are migrated from plaintext `Favorites.xml` into the macOS Keychain.
+- New saves store hub passwords in Keychain and write `PasswordStore="Keychain"` instead of plaintext `Password`.
+- Non-macOS behavior remains unchanged for compatibility.
+
+Keychain item shape:
+
+- Class: generic password
+- Service: `org.eiskaltdcpp.hub-password`
+- Account: `<hub-server>|<nick>`
+
+If Keychain is unavailable or saving fails, the application falls back conservatively rather than losing the password.
+
+## Release checklist
+
+1. Build each target architecture.
+2. Run the app with a clean profile and with an existing profile.
+3. Verify single-instance forwarding and stale-lock recovery.
+4. Verify favorite hub password migration with a test hub entry.
+5. Sign with Developer ID and hardened runtime.
+6. Notarize and staple the DMG.
+7. Upload checksums and artifacts to GitHub Releases.

--- a/docs/macos-troubleshooting.md
+++ b/docs/macos-troubleshooting.md
@@ -1,0 +1,41 @@
+# macOS troubleshooting
+
+## App silently exits
+
+Run with timing and safe mode:
+
+```sh
+EiskaltDC++.app/Contents/MacOS/EiskaltDC++ --safe-mode --startup-timing
+```
+
+The modernized single-instance code should recover from stale Qt IPC files automatically. If a second launch cannot contact the first instance, it continues startup and prints a warning.
+
+## Slow startup
+
+Use:
+
+```sh
+EiskaltDC++.app/Contents/MacOS/EiskaltDC++ --startup-timing
+```
+
+Common slow phases:
+
+- `Hash database`: large `HashData.dat`/`HashIndex.xml`.
+- `Shared Files`: large shares, missing external volumes, or cold share cache.
+
+Recovery flags:
+
+- `--safe-mode`
+- `--skip-hash-load`
+- `--skip-share-refresh`
+- `--nonblocking-share-refresh`
+
+## Gatekeeper says the app is rejected
+
+Local builds are ad-hoc signed. Public distribution requires Developer ID signing and notarization:
+
+```sh
+macos/sign-and-notarize.sh dist/macos-arm64-release/EiskaltDC++.app 'Developer ID Application: Name (TEAMID)'
+```
+
+Set `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_SPECIFIC_PASSWORD` to notarize.

--- a/eiskaltdcpp-qt/src/WulforUtil.cpp
+++ b/eiskaltdcpp-qt/src/WulforUtil.cpp
@@ -487,7 +487,6 @@ QString WulforUtil::getNicks(const CID &cid, const QString &hintUrl){
 
 void WulforUtil::textToHtml(QString &str, bool print){
     if (print){
-        str.replace(";", "&#59;");
         str.replace("<", "&lt;");
         str.replace(">", "&gt;");
     }

--- a/eiskaltdcpp-qt/src/main.cpp
+++ b/eiskaltdcpp-qt/src/main.cpp
@@ -67,7 +67,9 @@ using namespace std;
 #endif
 
 #include <QApplication>
+#include <QElapsedTimer>
 #include <QMainWindow>
+#include <QProcessEnvironment>
 #include <QRegExp>
 #include <QObject>
 #include <QTextCodec>
@@ -76,12 +78,48 @@ using namespace std;
 #include <QtDBus>
 #endif
 
+namespace {
+
+struct QtStartupOptions {
+    bool safeMode = false;
+    bool skipHashLoad = false;
+    bool skipShareRefresh = false;
+    bool nonBlockingShareRefresh = false;
+    bool startupTiming = false;
+};
+
+QtStartupOptions startupOptions;
+QElapsedTimer startupTimer;
+qint64 lastStartupMark = 0;
+
+bool startupTimingEnabled()
+{
+    return startupOptions.startupTiming || qEnvironmentVariableIsSet("EISKALT_STARTUP_TIMING");
+}
+
+void startupMark(const QString& step)
+{
+    if (!startupTimingEnabled())
+        return;
+
+    if (!startupTimer.isValid())
+        startupTimer.start();
+
+    const qint64 now = startupTimer.elapsed();
+    std::cout << "Startup timing: +" << (now - lastStartupMark) << "ms (" << now << "ms) "
+              << step.toStdString() << std::endl;
+    lastStartupMark = now;
+}
+
+} // namespace
+
 void callBack(void *, const std::string &a)
 {
     std::cout << QObject::tr("Loading: ").toStdString() << a << std::endl;
+    startupMark(QString::fromStdString(a));
 }
 
-void parseCmdLine(const QStringList &);
+QtStartupOptions parseCmdLine(const QStringList &);
 
 #if !defined(Q_OS_WIN)
 #include <unistd.h>
@@ -130,7 +168,18 @@ int main(int argc, char *argv[])
     EiskaltApp app(argc, argv, _q(dcpp::Util::getLoginName()+"EDCPP"));
     int ret = 0;
 
-    parseCmdLine(app.arguments());
+    startupOptions = parseCmdLine(app.arguments());
+    if (startupOptions.safeMode) {
+        startupOptions.skipHashLoad = true;
+        startupOptions.skipShareRefresh = true;
+        startupOptions.nonBlockingShareRefresh = true;
+        std::cout << "Safe mode enabled: skipping hash load, share refresh, and autoconnect." << std::endl;
+    }
+    if (startupTimingEnabled()) {
+        startupTimer.start();
+        lastStartupMark = 0;
+        startupMark("application constructed");
+    }
 
     if (app.isRunning()){
         QStringList args = app.arguments();
@@ -149,7 +198,12 @@ int main(int argc, char *argv[])
     migrateConfig();
 #endif
 
-    dcpp::startup(callBack, nullptr);
+    dcpp::StartupOptions coreStartupOptions;
+    coreStartupOptions.skipHashLoad = startupOptions.skipHashLoad;
+    coreStartupOptions.skipShareRefresh = startupOptions.skipShareRefresh;
+    coreStartupOptions.nonBlockingShareRefresh = startupOptions.nonBlockingShareRefresh;
+    dcpp::startup(callBack, nullptr, coreStartupOptions);
+    startupMark("dcpp::startup complete");
     dcpp::TimerManager::getInstance()->start();
 
     HashManager::getInstance()->setPriority(Thread::IDLE);
@@ -161,6 +215,7 @@ int main(int argc, char *argv[])
     app.setApplicationVersion(QString::fromStdString(eiskaltdcppVersionString));
     
     GlobalTimer::newInstance();
+    startupMark("GlobalTimer initialized");
 
     WulforSettings::newInstance();
     WulforSettings::getInstance()->load();
@@ -180,6 +235,7 @@ int main(int argc, char *argv[])
 
     if (WulforUtil::getInstance()->loadIcons())
         std::cout << QObject::tr("Application icons has been loaded").toStdString() << std::endl;
+    startupMark("icons loaded");
 
     app.setWindowIcon(WICON(WulforUtil::eiICON_APPL));
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 1))
@@ -189,6 +245,7 @@ int main(int argc, char *argv[])
     ArenaWidgetManager::newInstance();
 
     MainWindow::newInstance();
+    startupMark("MainWindow created");
 #if defined(Q_OS_MAC)
     MainWindow::getInstance()->setUnload(false);
     QObject::connect(&app, SIGNAL(clickedOnDock()),
@@ -214,6 +271,7 @@ int main(int argc, char *argv[])
 #endif
 
     Notification::newInstance();
+    startupMark("notifications initialized");
 
 #ifdef USE_JS
     ScriptEngine::newInstance();
@@ -224,11 +282,14 @@ int main(int argc, char *argv[])
     ArenaWidgetFactory().create< dcpp::Singleton, FinishedDownloads >();
     ArenaWidgetFactory().create< dcpp::Singleton, QueuedUsers >();
 
-    MainWindow::getInstance()->autoconnect();
+    if (!startupOptions.safeMode)
+        MainWindow::getInstance()->autoconnect();
+    startupMark("autoconnect complete");
     MainWindow::getInstance()->parseCmdLine(app.arguments());
 
     if (!WBGET(WB_MAINWINDOW_HIDE) || !WBGET(WB_TRAY_ENABLED))
         MainWindow::getInstance()->show();
+    startupMark("main window shown");
 
     ret = app.exec();
 
@@ -267,10 +328,17 @@ int main(int argc, char *argv[])
     return ret;
 }
 
-void parseCmdLine(const QStringList &args){
+QtStartupOptions parseCmdLine(const QStringList &args){
+    QtStartupOptions options;
     for (const auto &arg : args){
         if (arg == "-h" || arg == "--help"){
             About().printHelp();
+            std::cout << "\nModern macOS recovery options:\n"
+                      << "  --safe-mode                 skip hash load, share refresh, and autoconnect\n"
+                      << "  --skip-hash-load            skip loading HashIndex/HashData during startup\n"
+                      << "  --skip-share-refresh        skip initial shared-file refresh/cache load\n"
+                      << "  --nonblocking-share-refresh do not block startup on initial share scan\n"
+                      << "  --startup-timing            print startup phase timings\n";
 
             exit(0);
         }
@@ -279,7 +347,20 @@ void parseCmdLine(const QStringList &args){
 
             exit(0);
         }
+        else if (arg == "--safe-mode")
+            options.safeMode = true;
+        else if (arg == "--skip-hash-load")
+            options.skipHashLoad = true;
+        else if (arg == "--skip-share-refresh")
+            options.skipShareRefresh = true;
+        else if (arg == "--nonblocking-share-refresh")
+            options.nonBlockingShareRefresh = true;
+        else if (arg == "--startup-timing")
+            options.startupTiming = true;
     }
+    if (options.skipHashLoad)
+        options.skipShareRefresh = true;
+    return options;
 }
 
 #if !defined (Q_OS_WIN) && !defined (Q_OS_HAIKU)

--- a/eiskaltdcpp-qt/src/main.cpp
+++ b/eiskaltdcpp-qt/src/main.cpp
@@ -124,7 +124,7 @@ QtStartupOptions parseCmdLine(const QStringList &);
 #if !defined(Q_OS_WIN)
 #include <unistd.h>
 #include <signal.h>
-#if !defined (Q_OS_HAIKU) && defined (__GLIBC__)
+#if !defined (Q_OS_HAIKU)
 #include <execinfo.h>
 
 #ifdef ENABLE_STACKTRACE
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
         return 0;
     }
 
-#if !defined (Q_OS_WIN) && !defined (Q_OS_HAIKU) && defined (__GLIBC__)
+#if !defined (Q_OS_WIN) && !defined (Q_OS_HAIKU)
     installHandlers();
 #endif
 

--- a/eiskaltdcpp-qt/src/qtsingleapp/qtsinglecoreapplication.cpp
+++ b/eiskaltdcpp-qt/src/qtsingleapp/qtsinglecoreapplication.cpp
@@ -12,41 +12,64 @@
 
 #include <QTimer>
 #include <QByteArray>
+#include <QCryptographicHash>
+#include <QDataStream>
 #include <QDebug>
+#include <QLocalSocket>
 
 static const unsigned int SHARED_MEM_SIZE = 2048;
 
 QtSingleCoreApplication::QtSingleCoreApplication(int &argc, char **argv, const QString &uniqueKey)
-    : QApplication(argc, argv), sharedMemory()
+    : QApplication(argc, argv), localServer(nullptr), sharedMemory()
 {
     sharedMemory.setKey(uniqueKey);
+    localServerName = QStringLiteral("edcpp-") +
+        QString::fromLatin1(QCryptographicHash::hash(uniqueKey.toUtf8(), QCryptographicHash::Sha1).toHex().left(16));
 
-    if (sharedMemory.attach())
+    QLocalSocket socket;
+    socket.connectToServer(localServerName, QIODevice::WriteOnly);
+    if (socket.waitForConnected(250)) {
         _isRunning = true;
-    else {
-        _isRunning = false;
-        // attach data to shared memory.
-        QByteArray byteArray("0"); // default value to note that no message is available.
-        byteArray.resize(SHARED_MEM_SIZE);
+        return;
+    }
 
-        if (!sharedMemory.create(byteArray.size()))
-        {
-            qDebug("Unable to create single instance.");
-            return;
-        }
+    QLocalServer::removeServer(localServerName);
+    localServer = new QLocalServer(this);
+    if (!localServer->listen(localServerName)) {
+        qWarning() << "Unable to create local single-instance server" << localServerName << localServer->errorString();
+        delete localServer;
+        localServer = nullptr;
+    } else {
+        connect(localServer, SIGNAL(newConnection()), this, SLOT(receiveLocalConnection()));
+    }
+
+    _isRunning = false;
+
+    // Keep the legacy shared-memory channel for crash-handler cleanup and compatibility.
+    QByteArray byteArray("0"); // default value to note that no message is available.
+    byteArray.resize(SHARED_MEM_SIZE);
+
+    if (!sharedMemory.create(byteArray.size()))
+    {
+        sharedMemory.attach();
+        sharedMemory.detach();
+        sharedMemory.create(byteArray.size());
+    }
+
+    if (sharedMemory.isAttached()) {
         sharedMemory.lock();
         char *to = (char*)sharedMemory.data();
         const char *from = byteArray.data();
         memcpy(to, from, qMin(sharedMemory.size(), byteArray.size()));
         sharedMemory.unlock();
-        // start checking for messages of other instances.
-        QTimer *timer = new QTimer(this);
-        connect(timer, SIGNAL(timeout()), this, SLOT(checkForMessage()));
-        timer->start(2000);
     }
 }
 
 QtSingleCoreApplication::~QtSingleCoreApplication(){
+    if (localServer) {
+        localServer->close();
+        QLocalServer::removeServer(localServerName);
+    }
     sharedMemory.detach();
 }
 
@@ -61,25 +84,51 @@ bool QtSingleCoreApplication::sendMessage(QString message)
     if (!_isRunning)
         return false;
 
-    if (message.length() > sharedMemory.size() - 2)//two reserved bytes
-        message = message.left(sharedMemory.size()-2);
+    QLocalSocket socket;
+    socket.connectToServer(localServerName, QIODevice::WriteOnly);
+    if (!socket.waitForConnected(1000))
+        return false;
 
-    QByteArray byteArray("1");
-    byteArray.append(message.toUtf8());
-    byteArray.append('\0');
+    QByteArray payload = message.toUtf8();
+    QByteArray frame;
+    QDataStream stream(&frame, QIODevice::WriteOnly);
+    stream.setVersion(QDataStream::Qt_5_0);
+    stream << static_cast<quint32>(payload.size());
+    frame.append(payload);
 
-    sharedMemory.lock();
-
-    char *to = (char*)sharedMemory.data();
-    const char *from = byteArray.data();
-
-    memcpy(to, from, qMin(sharedMemory.size(), byteArray.size()));
-
-    sharedMemory.unlock();
-
-    return true;
+    if (socket.write(frame) != frame.size())
+        return false;
+    return socket.waitForBytesWritten(1000);
 }
 
+
+void QtSingleCoreApplication::receiveLocalConnection()
+{
+    while (localServer && localServer->hasPendingConnections()) {
+        QLocalSocket *socket = localServer->nextPendingConnection();
+        if (!socket)
+            continue;
+
+        while (socket->bytesAvailable() < static_cast<qint64>(sizeof(quint32)) && socket->waitForReadyRead(1000)) { }
+
+        if (socket->bytesAvailable() >= static_cast<qint64>(sizeof(quint32))) {
+            QDataStream stream(socket);
+            stream.setVersion(QDataStream::Qt_5_0);
+            quint32 payloadSize = 0;
+            stream >> payloadSize;
+
+            while (socket->bytesAvailable() < static_cast<qint64>(payloadSize) && socket->waitForReadyRead(1000)) { }
+
+            if (socket->bytesAvailable() >= static_cast<qint64>(payloadSize)) {
+                QByteArray payload = socket->read(payloadSize);
+                if (!payload.isEmpty())
+                    emit messageReceived(QString::fromUtf8(payload));
+            }
+        }
+        socket->disconnectFromServer();
+        socket->deleteLater();
+    }
+}
 
 void QtSingleCoreApplication::checkForMessage()
 {

--- a/eiskaltdcpp-qt/src/qtsingleapp/qtsinglecoreapplication.h
+++ b/eiskaltdcpp-qt/src/qtsingleapp/qtsinglecoreapplication.h
@@ -9,6 +9,7 @@
 
 
 #include <QApplication>
+#include <QLocalServer>
 #include <QSharedMemory>
 
 class QtSingleCoreApplication : public QApplication
@@ -32,5 +33,10 @@ Q_SIGNALS:
 
 private:
     bool _isRunning;
+    QString localServerName;
+    QLocalServer *localServer;
     QSharedMemory sharedMemory;
+
+private Q_SLOTS:
+    void receiveLocalConnection();
 };

--- a/extra/upnpc.cpp
+++ b/extra/upnpc.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "upnpc.h"
+#include "dcpp/LogManager.h"
 #include "dcpp/Util.h"
 #include "dcpp/SettingsManager.h"
 #ifndef STATICLIB
@@ -31,6 +32,14 @@
 #include <miniupnpc/miniupnpc.h>
 #include <miniupnpc/upnpcommands.h>
 #include <miniupnpc/upnperrors.h>
+
+namespace {
+
+void logMiniUPnPFailure(const std::string& message) {
+    dcpp::LogManager::getInstance()->message("UPnP: MiniUPnP: " + message);
+}
+
+}
 
 static UPNPUrls urls;
 static IGDdatas data;
@@ -45,23 +54,33 @@ bool UPnPc::init()
     const char *multicast_interface = SettingsManager::getInstance()->isDefault(SettingsManager::BIND_ADDRESS) ? nullptr : bind_address.c_str();
 
 #if (MINIUPNPC_API_VERSION >= 14)
-    UPNPDev *devices = upnpDiscover(5000, multicast_interface, nullptr, 0, 0, 2, nullptr);
+    int discoverError = 0;
+    UPNPDev *devices = upnpDiscover(5000, multicast_interface, nullptr, 0, 0, 2, &discoverError);
 #else
     UPNPDev *devices = upnpDiscover(5000, multicast_interface, nullptr, 0, 0, nullptr);
 #endif
 
-    if (!devices)
+    if (!devices) {
+#if (MINIUPNPC_API_VERSION >= 14)
+        logMiniUPnPFailure("SSDP discovery found no devices (error " + std::to_string(discoverError) + ")");
+#else
+        logMiniUPnPFailure("SSDP discovery found no devices");
+#endif
         return false;
+    }
 
 #if (MINIUPNPC_API_VERSION >= 18)
-    bool ret = UPNP_GetValidIGD(devices, &urls, &data, nullptr, 0, nullptr, 0);
+    const int ret = UPNP_GetValidIGD(devices, &urls, &data, nullptr, 0, nullptr, 0);
 #else
-    bool ret = UPNP_GetValidIGD(devices, &urls, &data, nullptr, 0);
+    const int ret = UPNP_GetValidIGD(devices, &urls, &data, nullptr, 0);
 #endif
 
     freeUPNPDevlist(devices);
 
-    return ret;
+    if(ret == 0)
+        logMiniUPnPFailure("SSDP discovery found devices, but no valid Internet Gateway Device was available");
+
+    return ret != 0;
 }
 
 bool UPnPc::add(const string& port, const UPnP::Protocol protocol, const string& description)

--- a/extra/upnpc.cpp
+++ b/extra/upnpc.cpp
@@ -66,8 +66,29 @@ bool UPnPc::init()
 
 bool UPnPc::add(const string& port, const UPnP::Protocol protocol, const string& description)
 {
-    return UPNP_AddPortMapping(urls.controlURL, data.first.servicetype, port.c_str(), port.c_str(),
-        Util::getLocalIp(AF_INET).c_str(), description.c_str(), protocols[protocol], nullptr, nullptr) == UPNPCOMMAND_SUCCESS;
+    const string localIp = Util::getLocalIp(AF_INET);
+    const int addResult = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype, port.c_str(), port.c_str(),
+        localIp.c_str(), description.c_str(), protocols[protocol], nullptr, nullptr);
+
+    if (addResult == UPNPCOMMAND_SUCCESS)
+        return true;
+
+    /*
+     * Some IGDs reject AddPortMapping when the same mapping already exists.
+     * This happens frequently after an unclean app exit or when the router keeps
+     * leased mappings around across client restarts. Treat an exact existing
+     * mapping to this host and port as success; connectivity is already active,
+     * and adding a rule lets normal shutdown clean it up later.
+     */
+    char intClient[64] = { 0 };
+    char intPort[16] = { 0 };
+    char desc[128] = { 0 };
+    char enabled[8] = { 0 };
+    char leaseDuration[16] = { 0 };
+    const int existingResult = UPNP_GetSpecificPortMappingEntry(urls.controlURL, data.first.servicetype,
+        port.c_str(), protocols[protocol], nullptr, intClient, intPort, desc, enabled, leaseDuration);
+
+    return existingResult == UPNPCOMMAND_SUCCESS && localIp == intClient && port == intPort;
 }
 
 bool UPnPc::remove(const string& port, const UPnP::Protocol protocol)

--- a/macos/build-app.sh
+++ b/macos/build-app.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+arch="arm64"
+preset=""
+package=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --arch) arch="$2"; shift 2 ;;
+    --preset) preset="$2"; shift 2 ;;
+    --no-package) package=0; shift ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: macos/build-app.sh [--arch arm64|x86_64] [--no-package]
+
+Builds EiskaltDC++ as a modern macOS app using Homebrew Qt 5.
+Set HOMEBREW_PREFIX to override the brew prefix; otherwise brew --prefix is used.
+USAGE
+      exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$preset" ]]; then
+  preset="macos-${arch}-release"
+fi
+
+export HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-$(brew --prefix)}"
+export PATH="$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/opt/ccache/libexec:$PATH"
+
+cmake --preset "$preset"
+cmake --build --preset "$preset" --parallel
+cmake --install "build/$preset"
+
+app="dist/$preset/EiskaltDC++.app"
+if [[ -d "$app" && -x "$HOMEBREW_PREFIX/opt/qt@5/bin/macdeployqt" ]]; then
+  "$HOMEBREW_PREFIX/opt/qt@5/bin/macdeployqt" "$app" -always-overwrite
+  codesign --force --deep --sign - "$app"
+  codesign --verify --deep --strict "$app"
+fi
+
+if [[ "$package" -eq 1 ]]; then
+  cmake --build --preset "$preset" --target package
+fi
+
+echo "Built preset $preset"

--- a/macos/build-app.sh
+++ b/macos/build-app.sh
@@ -29,7 +29,19 @@ fi
 export HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-$(brew --prefix)}"
 export PATH="$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/opt/ccache/libexec:$PATH"
 
-cmake --preset "$preset"
+qt5_cmake="$HOMEBREW_PREFIX/opt/qt@5/lib/cmake"
+cmake --preset "$preset" \
+  -DQt5_DIR="$qt5_cmake/Qt5" \
+  -DQt5Core_DIR="$qt5_cmake/Qt5Core" \
+  -DQt5Widgets_DIR="$qt5_cmake/Qt5Widgets" \
+  -DQt5Gui_DIR="$qt5_cmake/Qt5Gui" \
+  -DQt5Network_DIR="$qt5_cmake/Qt5Network" \
+  -DQt5Xml_DIR="$qt5_cmake/Qt5Xml" \
+  -DQt5Sql_DIR="$qt5_cmake/Qt5Sql" \
+  -DQt5Multimedia_DIR="$qt5_cmake/Qt5Multimedia" \
+  -DQt5Script_DIR="$qt5_cmake/Qt5Script" \
+  -DQt5Svg_DIR="$qt5_cmake/Qt5Svg" \
+  -DQt5UiTools_DIR="$qt5_cmake/Qt5UiTools"
 cmake --build --preset "$preset" --parallel
 cmake --install "build/$preset"
 

--- a/macos/build-app.sh
+++ b/macos/build-app.sh
@@ -4,18 +4,26 @@ set -euo pipefail
 arch="arm64"
 preset=""
 package=1
+install_app=0
+install_path="/Applications/EiskaltDC++.app"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --arch) arch="$2"; shift 2 ;;
     --preset) preset="$2"; shift 2 ;;
     --no-package) package=0; shift ;;
+    --install) install_app=1; shift ;;
+    --install-path) install_path="$2"; shift 2 ;;
     -h|--help)
       cat <<'USAGE'
-Usage: macos/build-app.sh [--arch arm64|x86_64] [--no-package]
+Usage: macos/build-app.sh [--arch arm64|x86_64] [--no-package] [--install] [--install-path /Applications/EiskaltDC++.app]
 
 Builds EiskaltDC++ as a modern macOS app using Homebrew Qt 5.
 Set HOMEBREW_PREFIX to override the brew prefix; otherwise brew --prefix is used.
+
+Options:
+  --install       Replace the app at --install-path with the fully deployed bundle from dist/.
+  --install-path  Destination app path for --install. Defaults to /Applications/EiskaltDC++.app.
 USAGE
       exit 0 ;;
     *) echo "Unknown option: $1" >&2; exit 2 ;;
@@ -50,6 +58,33 @@ if [[ -d "$app" && -x "$HOMEBREW_PREFIX/opt/qt@5/bin/macdeployqt" ]]; then
   "$HOMEBREW_PREFIX/opt/qt@5/bin/macdeployqt" "$app" -always-overwrite
   codesign --force --deep --sign - "$app"
   codesign --verify --deep --strict "$app"
+fi
+
+resources_count=0
+if [[ -d "$app/Contents/Resources" ]]; then
+  resources_count=$(find "$app/Contents/Resources" -type f | wc -l | tr -d ' ')
+fi
+if [[ "$resources_count" -lt 100 ]]; then
+  echo "Refusing to use incomplete app bundle: only $resources_count resource files in $app" >&2
+  exit 1
+fi
+
+if [[ "$install_app" -eq 1 ]]; then
+  if [[ ! -d "$app" ]]; then
+    echo "Built app bundle not found: $app" >&2
+    exit 1
+  fi
+  backup=""
+  if [[ -e "$install_path" ]]; then
+    backup="${install_path}.pre-install-$(date -u +%Y%m%d-%H%M%S)"
+    mv "$install_path" "$backup"
+  fi
+  ditto "$app" "$install_path"
+  codesign --verify --deep --strict "$install_path"
+  echo "Installed $install_path from $app"
+  if [[ -n "$backup" ]]; then
+    echo "Previous app saved at $backup"
+  fi
 fi
 
 if [[ "$package" -eq 1 ]]; then

--- a/macos/merge-universal-app.sh
+++ b/macos/merge-universal-app.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "Usage: macos/merge-universal-app.sh arm64/EiskaltDC++.app x86_64/EiskaltDC++.app out/EiskaltDC++.app" >&2
+  exit 2
+fi
+
+arm_app="$1"
+x64_app="$2"
+out_app="$3"
+rm -rf "$out_app"
+cp -R "$arm_app" "$out_app"
+
+while IFS= read -r -d '' arm_file; do
+  rel="${arm_file#$arm_app/}"
+  x64_file="$x64_app/$rel"
+  out_file="$out_app/$rel"
+  if [[ -f "$x64_file" ]] && file "$arm_file" | grep -q 'Mach-O'; then
+    lipo -create "$arm_file" "$x64_file" -output "$out_file"
+  fi
+done < <(find "$arm_app" -type f -print0)
+
+codesign --force --deep --sign - "$out_app"
+file "$out_app/Contents/MacOS/EiskaltDC++"

--- a/macos/sign-and-notarize.sh
+++ b/macos/sign-and-notarize.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: macos/sign-and-notarize.sh /path/to/EiskaltDC++.app 'Developer ID Application: Name (TEAMID)' [output.dmg]" >&2
+  exit 2
+fi
+
+app="$1"
+identity="$2"
+dmg="${3:-EiskaltDC++-macos.dmg}"
+
+codesign --force --deep --timestamp --options runtime --sign "$identity" "$app"
+codesign --verify --deep --strict --verbose=2 "$app"
+
+rm -f "$dmg"
+hdiutil create -volname "EiskaltDC++" -srcfolder "$app" -ov -format UDZO "$dmg"
+codesign --force --timestamp --sign "$identity" "$dmg"
+
+if [[ -n "${APPLE_ID:-}" && -n "${APPLE_TEAM_ID:-}" && -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
+  xcrun notarytool submit "$dmg" \
+    --apple-id "$APPLE_ID" \
+    --team-id "$APPLE_TEAM_ID" \
+    --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+    --wait
+  xcrun stapler staple "$dmg"
+  spctl -a -vv -t open --context context:primary-signature "$dmg"
+else
+  echo "Skipping notarization; set APPLE_ID, APPLE_TEAM_ID, and APPLE_APP_SPECIFIC_PASSWORD."
+fi


### PR DESCRIPTION
## Summary

Modernizes EiskaltDC++ on macOS after several years without native macOS release work.

This PR focuses on making the app launch reliably on current macOS, building native Apple Silicon artifacts, and improving recovery/security posture without disrupting non-macOS behavior.

### Launch reliability / resilience

- Replace stale-prone shared-memory-only single-instance handling with `QLocalServer` / `QLocalSocket` liveness checks.
- Automatically remove stale local server state.
- Forward second-launch URLs/arguments immediately to the running instance.
- Continue startup if an assumed existing instance cannot be contacted instead of silently exiting.
- Add recovery flags:
  - `--safe-mode`
  - `--skip-hash-load`
  - `--skip-share-refresh`
  - `--nonblocking-share-refresh`
  - `--startup-timing`
- Add startup timing diagnostics around major startup phases.

### macOS build / distribution

- Add `CMakePresets.json` for reproducible Homebrew-based macOS builds.
- Add `macos/build-app.sh` for local arm64/x86_64 app builds.
- Add `macos/sign-and-notarize.sh` for Developer ID signing/notarization.
- Add `macos/merge-universal-app.sh` for merging separate thin apps into a universal app.
- Add GitHub Actions workflow for macOS arm64/x86_64 builds.

### Security

- Add macOS Keychain-backed favorite hub password storage.
- Migrate legacy plaintext `Favorites.xml` passwords into Keychain.
- Avoid writing plaintext `Password` attributes on macOS when Keychain save succeeds.
- Keep non-macOS storage behavior unchanged.
- Fall back conservatively if Keychain save fails so passwords are not lost.

### Docs

- Add `docs/macos-modernization.md`.
- Add `docs/macos-troubleshooting.md`.

## Test plan

Verified locally on Apple Silicon macOS:

- `cmake --list-presets`
- `cmake --build build-modern-arm64 --parallel 8`
- `cmake --install build-modern-arm64`
- `macdeployqt` against the generated `.app`
- `codesign --force --deep --sign - EiskaltDC++.app`
- `codesign --verify --deep --strict EiskaltDC++.app`
- `file EiskaltDC++.app/Contents/MacOS/EiskaltDC++` reports `Mach-O 64-bit executable arm64`
- `EiskaltDC++ --help` lists the new recovery flags
- Clean-profile launch with:
  `EiskaltDC++ --safe-mode --startup-timing`
- Verified startup reaches `main window shown`
- Verified second-instance forwarding exits cleanly while the primary app remains running
- `git diff --cached --check`
- `python3 -m json.tool CMakePresets.json`
- `bash -n macos/*.sh`

## Notes

A true universal app still requires separately built arm64 and x86_64 app bundles because stock Homebrew Qt/dependencies are usually thin per architecture. The included merge script documents and automates the final `lipo` merge/re-sign step.
